### PR TITLE
Fix duplicate entries in 2014 Gordon County primary file

### DIFF
--- a/2014/20140520__ga__primary__gordon__precinct.csv
+++ b/2014/20140520__ga__primary__gordon__precinct.csv
@@ -519,19 +519,19 @@ Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
 Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3
 Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
 Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,43,9,19,0,71
-Gordon,SUGAR VALLEY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3
-Gordon,PLAINVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
-Gordon,SONORAVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
-Gordon,PINE CHAPEL,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
-Gordon,OOSTANAULA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
-Gordon,OAKMAN,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
-Gordon,GORDON COUNTY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
-Gordon,CALHOUN CITY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,1,0,0,7
-Gordon,LILY POND,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
-Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,1,0,0,4
-Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
-Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
-Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,17,2,0,0,19
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,R. "RITA" ROBINZINE,3,0,0,0,3
+Gordon,PLAINVILLE,State School Superintendent,,DEM,R. "RITA" ROBINZINE,0,0,0,0,0
+Gordon,SONORAVILLE,State School Superintendent,,DEM,R. "RITA" ROBINZINE,1,0,0,0,1
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,R. "RITA" ROBINZINE,1,0,0,0,1
+Gordon,OOSTANAULA,State School Superintendent,,DEM,R. "RITA" ROBINZINE,0,0,0,0,0
+Gordon,OAKMAN,State School Superintendent,,DEM,R. "RITA" ROBINZINE,0,0,0,0,0
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,R. "RITA" ROBINZINE,1,0,0,0,1
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,R. "RITA" ROBINZINE,6,1,0,0,7
+Gordon,LILY POND,State School Superintendent,,DEM,R. "RITA" ROBINZINE,1,0,0,0,1
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,R. "RITA" ROBINZINE,3,1,0,0,4
+Gordon,RED BUD,State School Superintendent,,DEM,R. "RITA" ROBINZINE,0,0,0,0,0
+Gordon,RESACA,State School Superintendent,,DEM,R. "RITA" ROBINZINE,1,0,0,0,1
+Gordon,,State School Superintendent,,DEM,R. "RITA" ROBINZINE,17,2,0,0,19
 Gordon,SUGAR VALLEY,State School Superintendent,,DEM,VALARIE D. WILSON,3,0,0,0,3
 Gordon,PLAINVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,0,0,5
 Gordon,SONORAVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,13,2,5,0,20

--- a/2014/20140520__ga__primary__gordon__precinct.csv
+++ b/2014/20140520__ga__primary__gordon__precinct.csv
@@ -1,1 +1,635 @@
-county,precinct,office,district,party,candidate,election_day,absentee_by_mail,advance_in_person,provisional,votesGordon,SUGAR VALLEY,United States Senator,,REP,PAUL COLLINS BROUN,11,0,2,0,13Gordon,PLAINVILLE,United States Senator,,REP,PAUL COLLINS BROUN,14,2,1,0,17Gordon,SONORAVILLE,United States Senator,,REP,PAUL COLLINS BROUN,34,0,3,0,37Gordon,PINE CHAPEL,United States Senator,,REP,PAUL COLLINS BROUN,7,0,1,0,8Gordon,OOSTANAULA,United States Senator,,REP,PAUL COLLINS BROUN,8,0,0,0,8Gordon,OAKMAN,United States Senator,,REP,PAUL COLLINS BROUN,8,0,0,0,8Gordon,GORDON COUNTY,United States Senator,,REP,PAUL COLLINS BROUN,30,1,3,0,34Gordon,CALHOUN CITY,United States Senator,,REP,PAUL COLLINS BROUN,38,4,21,0,63Gordon,LILY POND,United States Senator,,REP,PAUL COLLINS BROUN,18,0,1,0,19Gordon,FAIRMOUNT,United States Senator,,REP,PAUL COLLINS BROUN,12,0,1,0,13Gordon,RED BUD,United States Senator,,REP,PAUL COLLINS BROUN,7,1,3,0,11Gordon,RESACA,United States Senator,,REP,PAUL COLLINS BROUN,10,0,2,0,12Gordon,,United States Senator,,REP,PAUL COLLINS BROUN,197,8,38,0,243Gordon,SUGAR VALLEY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",2,0,0,0,2Gordon,PLAINVILLE,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1Gordon,SONORAVILLE,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",7,0,0,0,7Gordon,PINE CHAPEL,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1Gordon,OOSTANAULA,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,1,0,2Gordon,OAKMAN,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",3,1,0,0,4Gordon,GORDON COUNTY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",4,0,0,0,4Gordon,CALHOUN CITY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",7,0,4,0,11Gordon,LILY POND,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",0,0,1,0,1Gordon,FAIRMOUNT,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",3,0,0,0,3Gordon,RED BUD,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",2,0,0,0,2Gordon,RESACA,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1Gordon,,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",32,1,6,0,39Gordon,SUGAR VALLEY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",38,1,5,0,44Gordon,PLAINVILLE,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",53,1,3,0,57Gordon,SONORAVILLE,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",125,4,20,0,149Gordon,PINE CHAPEL,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",25,0,2,0,27Gordon,OOSTANAULA,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",21,3,1,0,25Gordon,OAKMAN,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",28,0,1,0,29Gordon,GORDON COUNTY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",123,6,44,1,174Gordon,CALHOUN CITY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",167,7,85,0,259Gordon,LILY POND,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",54,1,16,0,71Gordon,FAIRMOUNT,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",46,0,4,0,50Gordon,RED BUD,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",78,5,15,0,98Gordon,RESACA,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",36,0,4,0,40Gordon,,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",794,28,200,1,1023Gordon,SUGAR VALLEY,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2Gordon,PLAINVILLE,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2Gordon,SONORAVILLE,United States Senator,,REP,DERRICK E. GRAYSON,12,0,3,0,15Gordon,PINE CHAPEL,United States Senator,,REP,DERRICK E. GRAYSON,5,0,0,0,5Gordon,OOSTANAULA,United States Senator,,REP,DERRICK E. GRAYSON,2,0,1,0,3Gordon,OAKMAN,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2Gordon,GORDON COUNTY,United States Senator,,REP,DERRICK E. GRAYSON,5,0,1,0,6Gordon,CALHOUN CITY,United States Senator,,REP,DERRICK E. GRAYSON,5,0,1,0,6Gordon,LILY POND,United States Senator,,REP,DERRICK E. GRAYSON,1,0,0,0,1Gordon,FAIRMOUNT,United States Senator,,REP,DERRICK E. GRAYSON,6,0,0,0,6Gordon,RED BUD,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2Gordon,RESACA,United States Senator,,REP,DERRICK E. GRAYSON,3,0,0,0,3Gordon,,United States Senator,,REP,DERRICK E. GRAYSON,47,0,6,0,53Gordon,SUGAR VALLEY,United States Senator,,REP,KAREN C. HANDEL,24,0,6,0,30Gordon,PLAINVILLE,United States Senator,,REP,KAREN C. HANDEL,19,0,2,0,21Gordon,SONORAVILLE,United States Senator,,REP,KAREN C. HANDEL,74,2,15,0,91Gordon,PINE CHAPEL,United States Senator,,REP,KAREN C. HANDEL,13,0,4,0,17Gordon,OOSTANAULA,United States Senator,,REP,KAREN C. HANDEL,19,0,5,0,24Gordon,OAKMAN,United States Senator,,REP,KAREN C. HANDEL,16,0,2,0,18Gordon,GORDON COUNTY,United States Senator,,REP,KAREN C. HANDEL,56,1,13,0,70Gordon,CALHOUN CITY,United States Senator,,REP,KAREN C. HANDEL,107,1,30,0,138Gordon,LILY POND,United States Senator,,REP,KAREN C. HANDEL,26,3,5,0,34Gordon,FAIRMOUNT,United States Senator,,REP,KAREN C. HANDEL,27,1,3,0,31Gordon,RED BUD,United States Senator,,REP,KAREN C. HANDEL,34,0,4,0,38Gordon,RESACA,United States Senator,,REP,KAREN C. HANDEL,24,0,2,0,26Gordon,,United States Senator,,REP,KAREN C. HANDEL,439,8,91,0,538Gordon,SUGAR VALLEY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",34,0,3,0,37Gordon,PLAINVILLE,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",27,1,2,0,30Gordon,SONORAVILLE,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",92,2,16,0,110Gordon,PINE CHAPEL,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",23,0,0,0,23Gordon,OOSTANAULA,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",13,0,0,0,13Gordon,OAKMAN,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",14,0,1,0,15Gordon,GORDON COUNTY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",64,0,23,0,87Gordon,CALHOUN CITY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",99,1,25,0,125Gordon,LILY POND,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",30,1,4,0,35Gordon,FAIRMOUNT,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",33,0,3,0,36Gordon,RED BUD,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",40,0,7,0,47Gordon,RESACA,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",30,0,1,0,31Gordon,,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",499,5,85,0,589Gordon,SUGAR VALLEY,United States Senator,,REP,DAVID A. PERDUE,64,1,5,0,70Gordon,PLAINVILLE,United States Senator,,REP,DAVID A. PERDUE,61,2,9,0,72Gordon,SONORAVILLE,United States Senator,,REP,DAVID A. PERDUE,210,1,29,0,240Gordon,PINE CHAPEL,United States Senator,,REP,DAVID A. PERDUE,39,0,8,0,47Gordon,OOSTANAULA,United States Senator,,REP,DAVID A. PERDUE,26,1,5,0,32Gordon,OAKMAN,United States Senator,,REP,DAVID A. PERDUE,40,0,7,1,48Gordon,GORDON COUNTY,United States Senator,,REP,DAVID A. PERDUE,186,5,53,0,244Gordon,CALHOUN CITY,United States Senator,,REP,DAVID A. PERDUE,229,11,95,1,336Gordon,LILY POND,United States Senator,,REP,DAVID A. PERDUE,80,0,19,0,99Gordon,FAIRMOUNT,United States Senator,,REP,DAVID A. PERDUE,99,3,13,1,116Gordon,RED BUD,United States Senator,,REP,DAVID A. PERDUE,94,3,12,0,109Gordon,RESACA,United States Senator,,REP,DAVID A. PERDUE,61,1,6,1,69Gordon,,United States Senator,,REP,DAVID A. PERDUE,1189,28,261,4,1482Gordon,SUGAR VALLEY,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1Gordon,PLAINVILLE,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1Gordon,SONORAVILLE,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,1,0,1Gordon,PINE CHAPEL,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0Gordon,OOSTANAULA,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0Gordon,OAKMAN,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0Gordon,GORDON COUNTY,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0Gordon,CALHOUN CITY,United States Senator,,DEM,"O. ""STEEN"" MILES",3,0,2,0,5Gordon,LILY POND,United States Senator,,DEM,"O. ""STEEN"" MILES",2,0,0,0,2Gordon,FAIRMOUNT,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1Gordon,RED BUD,United States Senator,,DEM,"O. ""STEEN"" MILES",1,1,0,0,2Gordon,RESACA,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1Gordon,,United States Senator,,DEM,"O. ""STEEN"" MILES",10,1,3,0,14Gordon,SUGAR VALLEY,United States Senator,,DEM,M. MICHELLE NUNN,12,0,0,0,12Gordon,PLAINVILLE,United States Senator,,DEM,M. MICHELLE NUNN,8,0,1,0,9Gordon,SONORAVILLE,United States Senator,,DEM,M. MICHELLE NUNN,29,7,12,0,48Gordon,PINE CHAPEL,United States Senator,,DEM,M. MICHELLE NUNN,10,0,5,0,15Gordon,OOSTANAULA,United States Senator,,DEM,M. MICHELLE NUNN,8,0,6,0,14Gordon,OAKMAN,United States Senator,,DEM,M. MICHELLE NUNN,18,0,1,0,19Gordon,GORDON COUNTY,United States Senator,,DEM,M. MICHELLE NUNN,37,4,10,1,52Gordon,CALHOUN CITY,United States Senator,,DEM,M. MICHELLE NUNN,63,11,26,0,100Gordon,LILY POND,United States Senator,,DEM,M. MICHELLE NUNN,12,1,2,0,15Gordon,FAIRMOUNT,United States Senator,,DEM,M. MICHELLE NUNN,8,1,2,0,11Gordon,RED BUD,United States Senator,,DEM,M. MICHELLE NUNN,20,0,7,0,27Gordon,RESACA,United States Senator,,DEM,M. MICHELLE NUNN,9,0,0,0,9Gordon,,United States Senator,,DEM,M. MICHELLE NUNN,234,24,72,1,331Gordon,SUGAR VALLEY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1Gordon,PLAINVILLE,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0Gordon,SONORAVILLE,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0Gordon,PINE CHAPEL,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1Gordon,OOSTANAULA,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,1,0,1Gordon,OAKMAN,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1Gordon,GORDON COUNTY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",2,0,0,0,2Gordon,CALHOUN CITY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",5,1,1,0,7Gordon,LILY POND,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1Gordon,FAIRMOUNT,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0Gordon,RED BUD,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",2,0,0,0,2Gordon,RESACA,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0Gordon,,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",13,1,2,0,16Gordon,SUGAR VALLEY,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,0,0,4Gordon,PLAINVILLE,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1Gordon,SONORAVILLE,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1Gordon,PINE CHAPEL,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1Gordon,OOSTANAULA,United States Senator,,DEM,TODD ANTHONY ROBINSON,0,0,0,0,0Gordon,OAKMAN,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1Gordon,GORDON COUNTY,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,3,0,7Gordon,CALHOUN CITY,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,1,3,0,5Gordon,LILY POND,United States Senator,,DEM,TODD ANTHONY ROBINSON,3,0,0,0,3Gordon,FAIRMOUNT,United States Senator,,DEM,TODD ANTHONY ROBINSON,0,1,0,0,1Gordon,RED BUD,United States Senator,,DEM,TODD ANTHONY ROBINSON,2,1,1,0,4Gordon,RESACA,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,2,0,6Gordon,,United States Senator,,DEM,TODD ANTHONY ROBINSON,22,3,9,0,34Gordon,SUGAR VALLEY,Governor,,REP,JOHN D. BARGE,31,0,0,0,31Gordon,PLAINVILLE,Governor,,REP,JOHN D. BARGE,41,2,4,0,47Gordon,SONORAVILLE,Governor,,REP,JOHN D. BARGE,112,2,14,0,128Gordon,PINE CHAPEL,Governor,,REP,JOHN D. BARGE,9,0,3,0,12Gordon,OOSTANAULA,Governor,,REP,JOHN D. BARGE,10,0,3,0,13Gordon,OAKMAN,Governor,,REP,JOHN D. BARGE,23,0,3,0,26Gordon,GORDON COUNTY,Governor,,REP,JOHN D. BARGE,82,1,19,0,102Gordon,CALHOUN CITY,Governor,,REP,JOHN D. BARGE,127,1,42,0,170Gordon,LILY POND,Governor,,REP,JOHN D. BARGE,49,1,8,0,58Gordon,FAIRMOUNT,Governor,,REP,JOHN D. BARGE,38,1,5,0,44Gordon,RED BUD,Governor,,REP,JOHN D. BARGE,58,2,7,0,67Gordon,RESACA,Governor,,REP,JOHN D. BARGE,15,0,0,0,15Gordon,,Governor,,REP,JOHN D. BARGE,595,10,108,0,713Gordon,SUGAR VALLEY,Governor,,REP,J. NATHAN DEAL (I),85,2,16,0,103Gordon,PLAINVILLE,Governor,,REP,J. NATHAN DEAL (I),96,2,11,0,109Gordon,SONORAVILLE,Governor,,REP,J. NATHAN DEAL (I),358,7,68,0,433Gordon,PINE CHAPEL,Governor,,REP,J. NATHAN DEAL (I),83,0,11,0,94Gordon,OOSTANAULA,Governor,,REP,J. NATHAN DEAL (I),56,3,9,0,68Gordon,OAKMAN,Governor,,REP,J. NATHAN DEAL (I),66,0,7,1,74Gordon,GORDON COUNTY,Governor,,REP,J. NATHAN DEAL (I),268,10,104,0,382Gordon,CALHOUN CITY,Governor,,REP,J. NATHAN DEAL (I),374,17,162,1,554Gordon,LILY POND,Governor,,REP,J. NATHAN DEAL (I),120,4,30,0,154Gordon,FAIRMOUNT,Governor,,REP,J. NATHAN DEAL (I),150,0,12,1,163Gordon,RED BUD,Governor,,REP,J. NATHAN DEAL (I),144,5,32,0,181Gordon,RESACA,Governor,,REP,J. NATHAN DEAL (I),111,2,12,1,126Gordon,,Governor,,REP,J. NATHAN DEAL (I),1911,52,474,4,2441Gordon,SUGAR VALLEY,Governor,,REP,DAVID E. PENNINGTON III,55,0,6,0,61Gordon,PLAINVILLE,Governor,,REP,DAVID E. PENNINGTON III,39,2,2,0,43Gordon,SONORAVILLE,Governor,,REP,DAVID E. PENNINGTON III,92,0,7,0,99Gordon,PINE CHAPEL,Governor,,REP,DAVID E. PENNINGTON III,18,0,1,0,19Gordon,OOSTANAULA,Governor,,REP,DAVID E. PENNINGTON III,19,1,1,0,21Gordon,OAKMAN,Governor,,REP,DAVID E. PENNINGTON III,20,1,1,0,22Gordon,GORDON COUNTY,Governor,,REP,DAVID E. PENNINGTON III,118,1,19,1,139Gordon,CALHOUN CITY,Governor,,REP,DAVID E. PENNINGTON III,157,6,47,0,210Gordon,LILY POND,Governor,,REP,DAVID E. PENNINGTON III,35,0,7,0,42Gordon,FAIRMOUNT,Governor,,REP,DAVID E. PENNINGTON III,41,2,7,0,50Gordon,RED BUD,Governor,,REP,DAVID E. PENNINGTON III,58,2,2,0,62Gordon,RESACA,Governor,,REP,DAVID E. PENNINGTON III,39,0,3,0,42Gordon,,Governor,,REP,DAVID E. PENNINGTON III,691,15,103,1,810Gordon,SUGAR VALLEY,Governor,,DEM,JASON J. CARTER,19,0,0,0,19Gordon,PLAINVILLE,Governor,,DEM,JASON J. CARTER,9,0,1,0,10Gordon,SONORAVILLE,Governor,,DEM,JASON J. CARTER,25,7,12,0,44Gordon,PINE CHAPEL,Governor,,DEM,JASON J. CARTER,12,0,5,0,17Gordon,OOSTANAULA,Governor,,DEM,JASON J. CARTER,8,0,7,0,15Gordon,OAKMAN,Governor,,DEM,JASON J. CARTER,19,0,1,0,20Gordon,GORDON COUNTY,Governor,,DEM,JASON J. CARTER,42,4,12,1,59Gordon,CALHOUN CITY,Governor,,DEM,JASON J. CARTER,69,14,27,0,110Gordon,LILY POND,Governor,,DEM,JASON J. CARTER,16,1,3,0,20Gordon,FAIRMOUNT,Governor,,DEM,JASON J. CARTER,7,2,1,0,10Gordon,RED BUD,Governor,,DEM,JASON J. CARTER,23,3,6,0,32Gordon,RESACA,Governor,,DEM,JASON J. CARTER,14,0,2,0,16Gordon,,Governor,,DEM,JASON J. CARTER,263,31,77,1,372Gordon,SUGAR VALLEY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",134,2,16,0,152Gordon,PLAINVILLE,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",131,3,8,0,142Gordon,SONORAVILLE,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",445,8,66,0,519Gordon,PINE CHAPEL,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",84,0,11,0,95Gordon,OOSTANAULA,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",68,4,12,0,84Gordon,OAKMAN,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",77,1,7,1,86Gordon,GORDON COUNTY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",370,12,116,1,499Gordon,CALHOUN CITY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",509,18,185,1,713Gordon,LILY POND,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",145,5,37,0,187Gordon,FAIRMOUNT,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",187,2,18,1,208Gordon,RED BUD,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",198,7,38,0,243Gordon,RESACA,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",124,1,13,1,139Gordon,,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",2472,63,527,5,3067Gordon,SUGAR VALLEY,Lieutenant Governor,,DEM,CONNIE J. STOKES,15,0,0,0,15Gordon,PLAINVILLE,Lieutenant Governor,,DEM,CONNIE J. STOKES,7,0,1,0,8Gordon,SONORAVILLE,Lieutenant Governor,,DEM,CONNIE J. STOKES,24,5,7,0,36Gordon,PINE CHAPEL,Lieutenant Governor,,DEM,CONNIE J. STOKES,8,0,4,0,12Gordon,OOSTANAULA,Lieutenant Governor,,DEM,CONNIE J. STOKES,7,0,5,0,12Gordon,OAKMAN,Lieutenant Governor,,DEM,CONNIE J. STOKES,15,0,1,0,16Gordon,GORDON COUNTY,Lieutenant Governor,,DEM,CONNIE J. STOKES,30,4,9,1,44Gordon,CALHOUN CITY,Lieutenant Governor,,DEM,CONNIE J. STOKES,57,10,25,0,92Gordon,LILY POND,Lieutenant Governor,,DEM,CONNIE J. STOKES,12,1,2,0,15Gordon,FAIRMOUNT,Lieutenant Governor,,DEM,CONNIE J. STOKES,8,2,1,0,11Gordon,RED BUD,Lieutenant Governor,,DEM,CONNIE J. STOKES,22,2,6,0,30Gordon,RESACA,Lieutenant Governor,,DEM,CONNIE J. STOKES,10,0,2,0,12Gordon,,Lieutenant Governor,,DEM,CONNIE J. STOKES,215,24,63,1,303Gordon,SUGAR VALLEY,Secretary Of State,,REP,BRIAN P. KEMP (I),128,2,14,0,144Gordon,PLAINVILLE,Secretary Of State,,REP,BRIAN P. KEMP (I),129,3,8,0,140Gordon,SONORAVILLE,Secretary Of State,,REP,BRIAN P. KEMP (I),418,7,64,0,489Gordon,PINE CHAPEL,Secretary Of State,,REP,BRIAN P. KEMP (I),77,0,11,0,88Gordon,OOSTANAULA,Secretary Of State,,REP,BRIAN P. KEMP (I),58,4,11,0,73Gordon,OAKMAN,Secretary Of State,,REP,BRIAN P. KEMP (I),74,1,7,1,83Gordon,GORDON COUNTY,Secretary Of State,,REP,BRIAN P. KEMP (I),355,12,105,1,473Gordon,CALHOUN CITY,Secretary Of State,,REP,BRIAN P. KEMP (I),499,16,174,1,690Gordon,LILY POND,Secretary Of State,,REP,BRIAN P. KEMP (I),137,4,37,0,178Gordon,FAIRMOUNT,Secretary Of State,,REP,BRIAN P. KEMP (I),179,2,17,1,199Gordon,RED BUD,Secretary Of State,,REP,BRIAN P. KEMP (I),193,6,35,0,234Gordon,RESACA,Secretary Of State,,REP,BRIAN P. KEMP (I),113,1,11,1,126Gordon,,Secretary Of State,,REP,BRIAN P. KEMP (I),2360,58,494,5,2917Gordon,SUGAR VALLEY,Secretary Of State,,DEM,GERALD B. BECKUM,3,0,0,0,3Gordon,PLAINVILLE,Secretary Of State,,DEM,GERALD B. BECKUM,1,0,1,0,2Gordon,SONORAVILLE,Secretary Of State,,DEM,GERALD B. BECKUM,12,0,2,0,14Gordon,PINE CHAPEL,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,1,0,5Gordon,OOSTANAULA,Secretary Of State,,DEM,GERALD B. BECKUM,3,0,2,0,5Gordon,OAKMAN,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,0,0,4Gordon,GORDON COUNTY,Secretary Of State,,DEM,GERALD B. BECKUM,11,2,5,0,18Gordon,CALHOUN CITY,Secretary Of State,,DEM,GERALD B. BECKUM,15,6,6,0,27Gordon,LILY POND,Secretary Of State,,DEM,GERALD B. BECKUM,2,0,1,0,3Gordon,FAIRMOUNT,Secretary Of State,,DEM,GERALD B. BECKUM,4,2,0,0,6Gordon,RED BUD,Secretary Of State,,DEM,GERALD B. BECKUM,6,1,4,0,11Gordon,RESACA,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,1,0,5Gordon,,Secretary Of State,,DEM,GERALD B. BECKUM,69,11,23,0,103Gordon,SUGAR VALLEY,Secretary Of State,,DEM,DOREEN CARTER,14,0,0,0,14Gordon,PLAINVILLE,Secretary Of State,,DEM,DOREEN CARTER,9,0,0,0,9Gordon,SONORAVILLE,Secretary Of State,,DEM,DOREEN CARTER,14,7,11,0,32Gordon,PINE CHAPEL,Secretary Of State,,DEM,DOREEN CARTER,5,0,4,0,9Gordon,OOSTANAULA,Secretary Of State,,DEM,DOREEN CARTER,4,0,5,0,9Gordon,OAKMAN,Secretary Of State,,DEM,DOREEN CARTER,13,0,1,0,14Gordon,GORDON COUNTY,Secretary Of State,,DEM,DOREEN CARTER,27,2,7,1,37Gordon,CALHOUN CITY,Secretary Of State,,DEM,DOREEN CARTER,49,7,17,0,73Gordon,LILY POND,Secretary Of State,,DEM,DOREEN CARTER,12,1,2,0,15Gordon,FAIRMOUNT,Secretary Of State,,DEM,DOREEN CARTER,4,0,1,0,5Gordon,RED BUD,Secretary Of State,,DEM,DOREEN CARTER,16,1,4,0,21Gordon,RESACA,Secretary Of State,,DEM,DOREEN CARTER,9,0,1,0,10Gordon,,Secretary Of State,,DEM,DOREEN CARTER,176,18,53,1,248Gordon,SUGAR VALLEY,Attorney General,,REP,SAMUEL S. OLENS (I),121,1,15,0,137Gordon,PLAINVILLE,Attorney General,,REP,SAMUEL S. OLENS (I),123,2,8,0,133Gordon,SONORAVILLE,Attorney General,,REP,SAMUEL S. OLENS (I),394,7,58,0,459Gordon,PINE CHAPEL,Attorney General,,REP,SAMUEL S. OLENS (I),72,0,9,0,81Gordon,OOSTANAULA,Attorney General,,REP,SAMUEL S. OLENS (I),51,4,11,0,66Gordon,OAKMAN,Attorney General,,REP,SAMUEL S. OLENS (I),74,1,5,1,81Gordon,GORDON COUNTY,Attorney General,,REP,SAMUEL S. OLENS (I),327,12,97,1,437Gordon,CALHOUN CITY,Attorney General,,REP,SAMUEL S. OLENS (I),455,17,166,1,639Gordon,LILY POND,Attorney General,,REP,SAMUEL S. OLENS (I),130,4,32,0,166Gordon,FAIRMOUNT,Attorney General,,REP,SAMUEL S. OLENS (I),161,2,14,1,178Gordon,RED BUD,Attorney General,,REP,SAMUEL S. OLENS (I),182,7,35,0,224Gordon,RESACA,Attorney General,,REP,SAMUEL S. OLENS (I),114,1,10,1,126Gordon,,Attorney General,,REP,SAMUEL S. OLENS (I),2204,58,460,5,2727Gordon,SUGAR VALLEY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",14,0,0,0,14Gordon,PLAINVILLE,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,0,1,0,9Gordon,SONORAVILLE,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",24,6,12,0,42Gordon,PINE CHAPEL,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,0,4,0,12Gordon,OOSTANAULA,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",6,0,7,0,13Gordon,OAKMAN,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",16,0,0,0,16Gordon,GORDON COUNTY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",31,4,11,1,47Gordon,CALHOUN CITY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",56,12,21,0,89Gordon,LILY POND,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",11,1,3,0,15Gordon,FAIRMOUNT,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,1,1,0,10Gordon,RED BUD,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",21,2,6,0,29Gordon,RESACA,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",10,0,2,0,12Gordon,,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",213,26,68,1,308Gordon,SUGAR VALLEY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),132,1,17,0,150Gordon,PLAINVILLE,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),132,2,8,0,142Gordon,SONORAVILLE,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),428,8,65,0,501Gordon,PINE CHAPEL,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),79,0,11,0,90Gordon,OOSTANAULA,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),59,4,9,0,72Gordon,OAKMAN,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),81,1,7,1,90Gordon,GORDON COUNTY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),347,11,103,1,462Gordon,CALHOUN CITY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),469,17,166,1,653Gordon,LILY POND,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),141,4,37,0,182Gordon,FAIRMOUNT,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),179,3,15,1,198Gordon,RED BUD,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),190,7,36,0,233Gordon,RESACA,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),123,1,11,1,136Gordon,,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),2360,59,485,5,2909Gordon,SUGAR VALLEY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,17,0,0,0,17Gordon,PLAINVILLE,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,0,1,0,9Gordon,SONORAVILLE,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,23,6,9,0,38Gordon,PINE CHAPEL,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,0,4,0,12Gordon,OOSTANAULA,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,7,0,6,0,13Gordon,OAKMAN,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,15,0,1,0,16Gordon,GORDON COUNTY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,33,4,11,1,49Gordon,CALHOUN CITY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,57,13,22,0,92Gordon,LILY POND,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,12,1,2,0,15Gordon,FAIRMOUNT,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,2,1,0,11Gordon,RED BUD,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,23,3,6,0,32Gordon,RESACA,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,13,0,2,0,15Gordon,,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,224,29,65,1,319Gordon,SUGAR VALLEY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),116,1,14,0,131Gordon,PLAINVILLE,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),122,2,9,0,133Gordon,SONORAVILLE,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),405,7,59,0,471Gordon,PINE CHAPEL,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),71,0,10,0,81Gordon,OOSTANAULA,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),51,4,11,0,66Gordon,OAKMAN,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),75,1,5,1,82Gordon,GORDON COUNTY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),323,11,96,1,431Gordon,CALHOUN CITY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),440,17,159,1,617Gordon,LILY POND,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),132,3,32,0,167Gordon,FAIRMOUNT,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),161,3,13,1,178Gordon,RED BUD,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),175,7,34,0,216Gordon,RESACA,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),116,1,10,1,128Gordon,,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),2187,57,452,5,2701Gordon,SUGAR VALLEY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,5,0,0,0,5Gordon,PLAINVILLE,Commissioner Of Insurance,,DEM,KEITH G. HEARD,2,0,0,0,2Gordon,SONORAVILLE,Commissioner Of Insurance,,DEM,KEITH G. HEARD,9,2,0,0,11Gordon,PINE CHAPEL,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,1,0,4Gordon,OOSTANAULA,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,1,0,4Gordon,OAKMAN,Commissioner Of Insurance,,DEM,KEITH G. HEARD,4,0,0,0,4Gordon,GORDON COUNTY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,16,3,3,0,22Gordon,CALHOUN CITY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,8,5,7,0,20Gordon,LILY POND,Commissioner Of Insurance,,DEM,KEITH G. HEARD,6,0,0,0,6Gordon,FAIRMOUNT,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,0,0,3Gordon,RED BUD,Commissioner Of Insurance,,DEM,KEITH G. HEARD,8,1,3,0,12Gordon,RESACA,Commissioner Of Insurance,,DEM,KEITH G. HEARD,5,0,0,0,5Gordon,,Commissioner Of Insurance,,DEM,KEITH G. HEARD,72,11,15,0,98Gordon,SUGAR VALLEY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",14,0,0,0,14Gordon,PLAINVILLE,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",8,0,0,0,8Gordon,SONORAVILLE,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",19,5,13,0,37Gordon,PINE CHAPEL,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",5,0,4,0,9Gordon,OOSTANAULA,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",4,0,6,0,10Gordon,OAKMAN,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",12,0,1,0,13Gordon,GORDON COUNTY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",23,1,10,1,35Gordon,CALHOUN CITY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",49,8,16,0,73Gordon,LILY POND,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",8,1,3,0,12Gordon,FAIRMOUNT,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",6,2,1,0,9Gordon,RED BUD,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",13,1,5,0,19Gordon,RESACA,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",7,0,2,0,9Gordon,,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",168,18,61,1,248Gordon,SUGAR VALLEY,State School Superintendent,,REP,MARY KAY BACALLAO,15,0,1,0,16Gordon,PLAINVILLE,State School Superintendent,,REP,MARY KAY BACALLAO,14,0,1,0,15Gordon,SONORAVILLE,State School Superintendent,,REP,MARY KAY BACALLAO,71,1,10,0,82Gordon,PINE CHAPEL,State School Superintendent,,REP,MARY KAY BACALLAO,12,0,0,0,12Gordon,OOSTANAULA,State School Superintendent,,REP,MARY KAY BACALLAO,12,2,0,0,14Gordon,OAKMAN,State School Superintendent,,REP,MARY KAY BACALLAO,11,0,2,0,13Gordon,GORDON COUNTY,State School Superintendent,,REP,MARY KAY BACALLAO,48,1,14,0,63Gordon,CALHOUN CITY,State School Superintendent,,REP,MARY KAY BACALLAO,57,1,24,0,82Gordon,LILY POND,State School Superintendent,,REP,MARY KAY BACALLAO,25,0,7,0,32Gordon,FAIRMOUNT,State School Superintendent,,REP,MARY KAY BACALLAO,17,0,1,0,18Gordon,RED BUD,State School Superintendent,,REP,MARY KAY BACALLAO,28,0,1,0,29Gordon,RESACA,State School Superintendent,,REP,MARY KAY BACALLAO,15,0,2,0,17Gordon,,State School Superintendent,,REP,MARY KAY BACALLAO,325,5,63,0,393Gordon,SUGAR VALLEY,State School Superintendent,,REP,ASHLEY D. BELL,15,0,1,0,16Gordon,PLAINVILLE,State School Superintendent,,REP,ASHLEY D. BELL,17,0,1,0,18Gordon,SONORAVILLE,State School Superintendent,,REP,ASHLEY D. BELL,42,2,7,0,51Gordon,PINE CHAPEL,State School Superintendent,,REP,ASHLEY D. BELL,12,0,1,0,13Gordon,OOSTANAULA,State School Superintendent,,REP,ASHLEY D. BELL,10,0,1,0,11Gordon,OAKMAN,State School Superintendent,,REP,ASHLEY D. BELL,9,1,1,0,11Gordon,GORDON COUNTY,State School Superintendent,,REP,ASHLEY D. BELL,38,0,7,0,45Gordon,CALHOUN CITY,State School Superintendent,,REP,ASHLEY D. BELL,40,0,11,0,51Gordon,LILY POND,State School Superintendent,,REP,ASHLEY D. BELL,15,0,3,0,18Gordon,FAIRMOUNT,State School Superintendent,,REP,ASHLEY D. BELL,24,0,2,0,26Gordon,RED BUD,State School Superintendent,,REP,ASHLEY D. BELL,17,0,1,0,18Gordon,RESACA,State School Superintendent,,REP,ASHLEY D. BELL,17,0,0,0,17Gordon,,State School Superintendent,,REP,ASHLEY D. BELL,256,3,36,0,295Gordon,SUGAR VALLEY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",12,1,2,0,15Gordon,PLAINVILLE,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",27,0,1,0,28Gordon,SONORAVILLE,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",62,1,10,0,73Gordon,PINE CHAPEL,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",8,0,4,0,12Gordon,OOSTANAULA,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",7,0,3,0,10Gordon,OAKMAN,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",10,0,0,0,10Gordon,GORDON COUNTY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",51,1,13,0,65Gordon,CALHOUN CITY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",72,4,33,0,109Gordon,LILY POND,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",18,2,3,0,23Gordon,FAIRMOUNT,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",21,0,4,1,26Gordon,RED BUD,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",26,0,7,0,33Gordon,RESACA,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",18,1,1,0,20Gordon,,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",332,10,81,1,424Gordon,SUGAR VALLEY,State School Superintendent,,REP,SHARYL H. DAWES,7,0,0,0,7Gordon,PLAINVILLE,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3Gordon,SONORAVILLE,State School Superintendent,,REP,SHARYL H. DAWES,9,0,1,0,10Gordon,PINE CHAPEL,State School Superintendent,,REP,SHARYL H. DAWES,1,0,1,0,2Gordon,OOSTANAULA,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3Gordon,OAKMAN,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3Gordon,GORDON COUNTY,State School Superintendent,,REP,SHARYL H. DAWES,15,0,5,0,20Gordon,CALHOUN CITY,State School Superintendent,,REP,SHARYL H. DAWES,22,0,4,0,26Gordon,LILY POND,State School Superintendent,,REP,SHARYL H. DAWES,6,0,1,0,7Gordon,FAIRMOUNT,State School Superintendent,,REP,SHARYL H. DAWES,5,0,1,0,6Gordon,RED BUD,State School Superintendent,,REP,SHARYL H. DAWES,6,1,0,0,7Gordon,RESACA,State School Superintendent,,REP,SHARYL H. DAWES,5,0,0,0,5Gordon,,State School Superintendent,,REP,SHARYL H. DAWES,85,1,13,0,99Gordon,SUGAR VALLEY,State School Superintendent,,REP,ALLEN BOWLES FORT,48,0,9,0,57Gordon,PLAINVILLE,State School Superintendent,,REP,ALLEN BOWLES FORT,50,4,6,0,60Gordon,SONORAVILLE,State School Superintendent,,REP,ALLEN BOWLES FORT,183,4,24,0,211Gordon,PINE CHAPEL,State School Superintendent,,REP,ALLEN BOWLES FORT,29,0,4,0,33Gordon,OOSTANAULA,State School Superintendent,,REP,ALLEN BOWLES FORT,24,1,7,0,32Gordon,OAKMAN,State School Superintendent,,REP,ALLEN BOWLES FORT,30,0,5,0,35Gordon,GORDON COUNTY,State School Superintendent,,REP,ALLEN BOWLES FORT,136,4,38,1,179Gordon,CALHOUN CITY,State School Superintendent,,REP,ALLEN BOWLES FORT,255,9,99,0,363Gordon,LILY POND,State School Superintendent,,REP,ALLEN BOWLES FORT,66,2,18,0,86Gordon,FAIRMOUNT,State School Superintendent,,REP,ALLEN BOWLES FORT,77,3,9,0,89Gordon,RED BUD,State School Superintendent,,REP,ALLEN BOWLES FORT,103,1,19,0,123Gordon,RESACA,State School Superintendent,,REP,ALLEN BOWLES FORT,38,0,6,1,45Gordon,,State School Superintendent,,REP,ALLEN BOWLES FORT,1039,28,244,2,1313Gordon,SUGAR VALLEY,State School Superintendent,,REP,NANCY T. JESTER,10,0,0,0,10Gordon,PLAINVILLE,State School Superintendent,,REP,NANCY T. JESTER,14,0,1,0,15Gordon,SONORAVILLE,State School Superintendent,,REP,NANCY T. JESTER,19,1,2,0,22Gordon,PINE CHAPEL,State School Superintendent,,REP,NANCY T. JESTER,3,0,2,0,5Gordon,OOSTANAULA,State School Superintendent,,REP,NANCY T. JESTER,6,0,0,0,6Gordon,OAKMAN,State School Superintendent,,REP,NANCY T. JESTER,3,0,1,0,4Gordon,GORDON COUNTY,State School Superintendent,,REP,NANCY T. JESTER,15,0,10,0,25Gordon,CALHOUN CITY,State School Superintendent,,REP,NANCY T. JESTER,17,1,8,0,26Gordon,LILY POND,State School Superintendent,,REP,NANCY T. JESTER,6,0,1,0,7Gordon,FAIRMOUNT,State School Superintendent,,REP,NANCY T. JESTER,7,0,2,0,9Gordon,RED BUD,State School Superintendent,,REP,NANCY T. JESTER,8,0,1,0,9Gordon,RESACA,State School Superintendent,,REP,NANCY T. JESTER,10,0,0,0,10Gordon,,State School Superintendent,,REP,NANCY T. JESTER,118,2,28,0,148Gordon,SUGAR VALLEY,State School Superintendent,,REP,T. FITZ JOHNSON,9,0,1,0,10Gordon,PLAINVILLE,State School Superintendent,,REP,T. FITZ JOHNSON,4,0,2,0,6Gordon,SONORAVILLE,State School Superintendent,,REP,T. FITZ JOHNSON,27,0,4,0,31Gordon,PINE CHAPEL,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,0,0,7Gordon,OOSTANAULA,State School Superintendent,,REP,T. FITZ JOHNSON,3,0,0,0,3Gordon,OAKMAN,State School Superintendent,,REP,T. FITZ JOHNSON,10,0,0,0,10Gordon,GORDON COUNTY,State School Superintendent,,REP,T. FITZ JOHNSON,24,0,4,0,28Gordon,CALHOUN CITY,State School Superintendent,,REP,T. FITZ JOHNSON,20,0,4,0,24Gordon,LILY POND,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,1,0,8Gordon,FAIRMOUNT,State School Superintendent,,REP,T. FITZ JOHNSON,14,0,0,0,14Gordon,RED BUD,State School Superintendent,,REP,T. FITZ JOHNSON,4,2,0,0,6Gordon,RESACA,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,0,0,7Gordon,,State School Superintendent,,REP,T. FITZ JOHNSON,136,2,16,0,154Gordon,SUGAR VALLEY,State School Superintendent,,REP,KIRA G. WILLIS,3,0,0,0,3Gordon,PLAINVILLE,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,0,2Gordon,SONORAVILLE,State School Superintendent,,REP,KIRA G. WILLIS,6,0,0,0,6Gordon,PINE CHAPEL,State School Superintendent,,REP,KIRA G. WILLIS,0,0,0,0,0Gordon,OOSTANAULA,State School Superintendent,,REP,KIRA G. WILLIS,3,0,0,0,3Gordon,OAKMAN,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,1,3Gordon,GORDON COUNTY,State School Superintendent,,REP,KIRA G. WILLIS,9,0,4,0,13Gordon,CALHOUN CITY,State School Superintendent,,REP,KIRA G. WILLIS,14,0,2,0,16Gordon,LILY POND,State School Superintendent,,REP,KIRA G. WILLIS,6,0,0,0,6Gordon,FAIRMOUNT,State School Superintendent,,REP,KIRA G. WILLIS,4,0,0,0,4Gordon,RED BUD,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,0,2Gordon,RESACA,State School Superintendent,,REP,KIRA G. WILLIS,1,0,0,0,1Gordon,,State School Superintendent,,REP,KIRA G. WILLIS,52,0,6,1,59Gordon,SUGAR VALLEY,State School Superintendent,,REP,RICHARD L. WOODS,22,1,1,0,24Gordon,PLAINVILLE,State School Superintendent,,REP,RICHARD L. WOODS,23,0,2,0,25Gordon,SONORAVILLE,State School Superintendent,,REP,RICHARD L. WOODS,57,0,12,0,69Gordon,PINE CHAPEL,State School Superintendent,,REP,RICHARD L. WOODS,16,0,1,0,17Gordon,OOSTANAULA,State School Superintendent,,REP,RICHARD L. WOODS,8,1,0,0,9Gordon,OAKMAN,State School Superintendent,,REP,RICHARD L. WOODS,20,0,0,0,20Gordon,GORDON COUNTY,State School Superintendent,,REP,RICHARD L. WOODS,54,4,23,0,81Gordon,CALHOUN CITY,State School Superintendent,,REP,RICHARD L. WOODS,46,3,26,1,76Gordon,LILY POND,State School Superintendent,,REP,RICHARD L. WOODS,19,0,4,0,23Gordon,FAIRMOUNT,State School Superintendent,,REP,RICHARD L. WOODS,23,0,3,0,26Gordon,RED BUD,State School Superintendent,,REP,RICHARD L. WOODS,24,3,3,0,30Gordon,RESACA,State School Superintendent,,REP,RICHARD L. WOODS,23,0,3,0,26Gordon,,State School Superintendent,,REP,RICHARD L. WOODS,335,12,78,1,426Gordon,SUGAR VALLEY,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2Gordon,PLAINVILLE,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1Gordon,SONORAVILLE,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,1,0,2Gordon,PINE CHAPEL,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2Gordon,OOSTANAULA,State School Superintendent,,DEM,TARNISHA L. DENT,0,0,2,0,2Gordon,OAKMAN,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2Gordon,GORDON COUNTY,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,1,0,2Gordon,CALHOUN CITY,State School Superintendent,,DEM,TARNISHA L. DENT,7,1,3,0,11Gordon,LILY POND,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1Gordon,FAIRMOUNT,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2Gordon,RED BUD,State School Superintendent,,DEM,TARNISHA L. DENT,3,0,4,0,7Gordon,RESACA,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1Gordon,,State School Superintendent,,DEM,TARNISHA L. DENT,23,1,11,0,35Gordon,SUGAR VALLEY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,0,0,2Gordon,PLAINVILLE,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,0,0,0Gordon,SONORAVILLE,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",1,0,0,0,1Gordon,PINE CHAPEL,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,2,0,4Gordon,OOSTANAULA,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,0,0,2Gordon,OAKMAN,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,0,0,0,3Gordon,GORDON COUNTY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",14,2,2,1,19Gordon,CALHOUN CITY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",10,3,7,0,20Gordon,LILY POND,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,1,1,0,5Gordon,FAIRMOUNT,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,0,0,0Gordon,RED BUD,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,0,1,0,4Gordon,RESACA,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,1,0,1Gordon,,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",40,6,14,1,61Gordon,SUGAR VALLEY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0Gordon,PLAINVILLE,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0Gordon,SONORAVILLE,State School Superintendent,,DEM,JURITA FOREHAND MAYS,4,0,1,0,5Gordon,PINE CHAPEL,State School Superintendent,,DEM,JURITA FOREHAND MAYS,2,0,0,0,2Gordon,OOSTANAULA,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0Gordon,OAKMAN,State School Superintendent,,DEM,JURITA FOREHAND MAYS,1,0,0,0,1Gordon,GORDON COUNTY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,4,0,3,0,7Gordon,CALHOUN CITY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,5,0,1,0,6Gordon,LILY POND,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0Gordon,FAIRMOUNT,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0Gordon,RED BUD,State School Superintendent,,DEM,JURITA FOREHAND MAYS,2,0,0,0,2Gordon,RESACA,State School Superintendent,,DEM,JURITA FOREHAND MAYS,1,0,0,0,1Gordon,,State School Superintendent,,DEM,JURITA FOREHAND MAYS,19,0,5,0,24Gordon,SUGAR VALLEY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2Gordon,PLAINVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2Gordon,SONORAVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,4,5,6,0,15Gordon,PINE CHAPEL,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,1,0,2Gordon,OOSTANAULA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,3,0,6Gordon,OAKMAN,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,0,0,0,6Gordon,GORDON COUNTY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,1,4,0,11Gordon,CALHOUN CITY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,10,3,4,0,17Gordon,LILY POND,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,1,0,3Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,43,9,19,0,71Gordon,SUGAR VALLEY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3Gordon,PLAINVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0Gordon,SONORAVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1Gordon,PINE CHAPEL,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1Gordon,OOSTANAULA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0Gordon,OAKMAN,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0Gordon,GORDON COUNTY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1Gordon,CALHOUN CITY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,1,0,0,7Gordon,LILY POND,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,1,0,0,4Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,17,2,0,0,19Gordon,SUGAR VALLEY,State School Superintendent,,DEM,VALARIE D. WILSON,3,0,0,0,3Gordon,PLAINVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,0,0,5Gordon,SONORAVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,13,2,5,0,20Gordon,PINE CHAPEL,State School Superintendent,,DEM,VALARIE D. WILSON,0,0,2,0,2Gordon,OOSTANAULA,State School Superintendent,,DEM,VALARIE D. WILSON,2,0,2,0,4Gordon,OAKMAN,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,1,0,6Gordon,GORDON COUNTY,State School Superintendent,,DEM,VALARIE D. WILSON,13,1,2,0,16Gordon,CALHOUN CITY,State School Superintendent,,DEM,VALARIE D. WILSON,21,4,7,0,32Gordon,LILY POND,State School Superintendent,,DEM,VALARIE D. WILSON,7,0,1,0,8Gordon,FAIRMOUNT,State School Superintendent,,DEM,VALARIE D. WILSON,1,1,1,0,3Gordon,RED BUD,State School Superintendent,,DEM,VALARIE D. WILSON,8,2,1,0,11Gordon,RESACA,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,1,0,6Gordon,,State School Superintendent,,DEM,VALARIE D. WILSON,83,10,23,0,116Gordon,SUGAR VALLEY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),114,1,16,0,131Gordon,PLAINVILLE,Commissioner Of Labor,,REP,J. MARK BUTLER (I),122,2,7,0,131Gordon,SONORAVILLE,Commissioner Of Labor,,REP,J. MARK BUTLER (I),396,7,60,0,463Gordon,PINE CHAPEL,Commissioner Of Labor,,REP,J. MARK BUTLER (I),70,0,10,0,80Gordon,OOSTANAULA,Commissioner Of Labor,,REP,J. MARK BUTLER (I),48,4,12,0,64Gordon,OAKMAN,Commissioner Of Labor,,REP,J. MARK BUTLER (I),80,1,6,1,88Gordon,GORDON COUNTY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),322,12,94,1,429Gordon,CALHOUN CITY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),438,16,161,1,616Gordon,LILY POND,Commissioner Of Labor,,REP,J. MARK BUTLER (I),128,3,32,0,163Gordon,FAIRMOUNT,Commissioner Of Labor,,REP,J. MARK BUTLER (I),162,2,14,1,179Gordon,RED BUD,Commissioner Of Labor,,REP,J. MARK BUTLER (I),175,7,35,0,217Gordon,RESACA,Commissioner Of Labor,,REP,J. MARK BUTLER (I),115,1,10,1,127Gordon,,Commissioner Of Labor,,REP,J. MARK BUTLER (I),2170,56,457,5,2688Gordon,SUGAR VALLEY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,13,0,0,0,13Gordon,PLAINVILLE,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,6,0,0,0,6Gordon,SONORAVILLE,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,23,6,11,0,40Gordon,PINE CHAPEL,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,9,0,4,0,13Gordon,OOSTANAULA,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,6,0,7,0,13Gordon,OAKMAN,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,16,0,1,0,17Gordon,GORDON COUNTY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,32,4,11,1,48Gordon,CALHOUN CITY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,53,12,16,0,81Gordon,LILY POND,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,12,1,3,0,16Gordon,FAIRMOUNT,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,7,2,1,0,10Gordon,RED BUD,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,21,2,6,0,29Gordon,RESACA,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,10,0,2,0,12Gordon,,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,208,27,62,1,298Gordon,SUGAR VALLEY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",104,2,8,0,114Gordon,PLAINVILLE,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",119,5,4,0,128Gordon,SONORAVILLE,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",382,7,61,0,450Gordon,PINE CHAPEL,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",70,0,9,0,79Gordon,OOSTANAULA,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",53,3,11,0,67Gordon,OAKMAN,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",68,0,4,1,73Gordon,GORDON COUNTY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",285,9,92,1,387Gordon,CALHOUN CITY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",388,19,143,0,550Gordon,LILY POND,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",138,4,33,0,175Gordon,FAIRMOUNT,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",150,1,16,1,168Gordon,RED BUD,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",170,5,32,0,207Gordon,RESACA,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",117,2,12,1,132Gordon,,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",2044,57,425,4,2530Gordon,SUGAR VALLEY,U.S. Representative,14,REP,KENNETH L. HERRON SR,67,0,14,0,81Gordon,PLAINVILLE,U.S. Representative,14,REP,KENNETH L. HERRON SR,56,1,10,0,67Gordon,SONORAVILLE,U.S. Representative,14,REP,KENNETH L. HERRON SR,171,2,30,0,203Gordon,PINE CHAPEL,U.S. Representative,14,REP,KENNETH L. HERRON SR,38,0,6,0,44Gordon,OOSTANAULA,U.S. Representative,14,REP,KENNETH L. HERRON SR,37,1,2,0,40Gordon,OAKMAN,U.S. Representative,14,REP,KENNETH L. HERRON SR,37,1,5,0,43Gordon,GORDON COUNTY,U.S. Representative,14,REP,KENNETH L. HERRON SR,172,4,50,0,226Gordon,CALHOUN CITY,U.S. Representative,14,REP,KENNETH L. HERRON SR,256,5,109,1,371Gordon,LILY POND,U.S. Representative,14,REP,KENNETH L. HERRON SR,69,1,13,0,83Gordon,FAIRMOUNT,U.S. Representative,14,REP,KENNETH L. HERRON SR,74,3,9,0,86Gordon,RED BUD,U.S. Representative,14,REP,KENNETH L. HERRON SR,81,4,9,0,94Gordon,RESACA,U.S. Representative,14,REP,KENNETH L. HERRON SR,45,0,3,0,48Gordon,,U.S. Representative,14,REP,KENNETH L. HERRON SR,1103,22,260,1,1386Gordon,SUGAR VALLEY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",119,1,18,0,138Gordon,PLAINVILLE,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",127,2,8,0,137Gordon,OOSTANAULA,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",52,3,12,0,67Gordon,GORDON COUNTY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",321,11,94,1,427Gordon,CALHOUN CITY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",435,16,160,1,612Gordon,LILY POND,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",133,3,31,0,167Gordon,RESACA,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",4,0,0,0,4Gordon,,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",1191,36,323,2,1552Gordon,SONORAVILLE,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",395,5,61,0,461Gordon,PINE CHAPEL,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",67,0,10,0,77Gordon,OAKMAN,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",77,1,6,1,85Gordon,FAIRMOUNT,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",159,2,16,1,178Gordon,RED BUD,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",170,7,37,0,214Gordon,RESACA,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",105,1,10,1,117Gordon,,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",973,16,140,3,1132Gordon,SUGAR VALLEY,State Representative,5,REP,JOHN D. MEADOWS (I),124,2,19,0,145Gordon,PLAINVILLE,State Representative,5,REP,JOHN D. MEADOWS (I),132,1,7,0,140Gordon,SONORAVILLE,State Representative,5,REP,JOHN D. MEADOWS (I),246,1,33,0,280Gordon,PINE CHAPEL,State Representative,5,REP,JOHN D. MEADOWS (I),77,0,10,0,87Gordon,OOSTANAULA,State Representative,5,REP,JOHN D. MEADOWS (I),58,4,11,0,73Gordon,GORDON COUNTY,State Representative,5,REP,JOHN D. MEADOWS (I),346,12,107,1,466Gordon,CALHOUN CITY,State Representative,5,REP,JOHN D. MEADOWS (I),484,19,187,1,691Gordon,LILY POND,State Representative,5,REP,JOHN D. MEADOWS (I),141,4,37,0,182Gordon,RED BUD,State Representative,5,REP,JOHN D. MEADOWS (I),180,7,32,0,219Gordon,RESACA,State Representative,5,REP,JOHN D. MEADOWS (I),117,1,9,1,128Gordon,,State Representative,5,REP,JOHN D. MEADOWS (I),1905,51,452,3,2411Gordon,SONORAVILLE,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",167,7,31,0,205Gordon,OAKMAN,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",79,1,5,1,86Gordon,FAIRMOUNT,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",170,2,17,1,190Gordon,RED BUD,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",1,0,4,0,5Gordon,,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",417,10,57,2,486Gordon,SONORAVILLE,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",9,0,2,0,11Gordon,OAKMAN,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",17,0,1,0,18Gordon,FAIRMOUNT,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",7,2,1,0,10Gordon,RED BUD,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",0,0,0,0,0Gordon,,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",33,2,4,0,39
+county,precinct,office,district,party,candidate,election_day,absentee_by_mail,advance_in_person,provisional,votes
+Gordon,SUGAR VALLEY,United States Senator,,REP,PAUL COLLINS BROUN,11,0,2,0,13
+Gordon,PLAINVILLE,United States Senator,,REP,PAUL COLLINS BROUN,14,2,1,0,17
+Gordon,SONORAVILLE,United States Senator,,REP,PAUL COLLINS BROUN,34,0,3,0,37
+Gordon,PINE CHAPEL,United States Senator,,REP,PAUL COLLINS BROUN,7,0,1,0,8
+Gordon,OOSTANAULA,United States Senator,,REP,PAUL COLLINS BROUN,8,0,0,0,8
+Gordon,OAKMAN,United States Senator,,REP,PAUL COLLINS BROUN,8,0,0,0,8
+Gordon,GORDON COUNTY,United States Senator,,REP,PAUL COLLINS BROUN,30,1,3,0,34
+Gordon,CALHOUN CITY,United States Senator,,REP,PAUL COLLINS BROUN,38,4,21,0,63
+Gordon,LILY POND,United States Senator,,REP,PAUL COLLINS BROUN,18,0,1,0,19
+Gordon,FAIRMOUNT,United States Senator,,REP,PAUL COLLINS BROUN,12,0,1,0,13
+Gordon,RED BUD,United States Senator,,REP,PAUL COLLINS BROUN,7,1,3,0,11
+Gordon,RESACA,United States Senator,,REP,PAUL COLLINS BROUN,10,0,2,0,12
+Gordon,,United States Senator,,REP,PAUL COLLINS BROUN,197,8,38,0,243
+Gordon,SUGAR VALLEY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",2,0,0,0,2
+Gordon,PLAINVILLE,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1
+Gordon,SONORAVILLE,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",7,0,0,0,7
+Gordon,PINE CHAPEL,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1
+Gordon,OOSTANAULA,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,1,0,2
+Gordon,OAKMAN,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",3,1,0,0,4
+Gordon,GORDON COUNTY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",4,0,0,0,4
+Gordon,CALHOUN CITY,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",7,0,4,0,11
+Gordon,LILY POND,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",0,0,1,0,1
+Gordon,FAIRMOUNT,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",3,0,0,0,3
+Gordon,RED BUD,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",2,0,0,0,2
+Gordon,RESACA,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",1,0,0,0,1
+Gordon,,United States Senator,,REP,"ARTHUR A. ""ART"" GARDNER",32,1,6,0,39
+Gordon,SUGAR VALLEY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",38,1,5,0,44
+Gordon,PLAINVILLE,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",53,1,3,0,57
+Gordon,SONORAVILLE,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",125,4,20,0,149
+Gordon,PINE CHAPEL,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",25,0,2,0,27
+Gordon,OOSTANAULA,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",21,3,1,0,25
+Gordon,OAKMAN,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",28,0,1,0,29
+Gordon,GORDON COUNTY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",123,6,44,1,174
+Gordon,CALHOUN CITY,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",167,7,85,0,259
+Gordon,LILY POND,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",54,1,16,0,71
+Gordon,FAIRMOUNT,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",46,0,4,0,50
+Gordon,RED BUD,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",78,5,15,0,98
+Gordon,RESACA,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",36,0,4,0,40
+Gordon,,United States Senator,,REP,"J.P. ""PHIL"" GINGREY",794,28,200,1,1023
+Gordon,SUGAR VALLEY,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2
+Gordon,PLAINVILLE,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2
+Gordon,SONORAVILLE,United States Senator,,REP,DERRICK E. GRAYSON,12,0,3,0,15
+Gordon,PINE CHAPEL,United States Senator,,REP,DERRICK E. GRAYSON,5,0,0,0,5
+Gordon,OOSTANAULA,United States Senator,,REP,DERRICK E. GRAYSON,2,0,1,0,3
+Gordon,OAKMAN,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2
+Gordon,GORDON COUNTY,United States Senator,,REP,DERRICK E. GRAYSON,5,0,1,0,6
+Gordon,CALHOUN CITY,United States Senator,,REP,DERRICK E. GRAYSON,5,0,1,0,6
+Gordon,LILY POND,United States Senator,,REP,DERRICK E. GRAYSON,1,0,0,0,1
+Gordon,FAIRMOUNT,United States Senator,,REP,DERRICK E. GRAYSON,6,0,0,0,6
+Gordon,RED BUD,United States Senator,,REP,DERRICK E. GRAYSON,2,0,0,0,2
+Gordon,RESACA,United States Senator,,REP,DERRICK E. GRAYSON,3,0,0,0,3
+Gordon,,United States Senator,,REP,DERRICK E. GRAYSON,47,0,6,0,53
+Gordon,SUGAR VALLEY,United States Senator,,REP,KAREN C. HANDEL,24,0,6,0,30
+Gordon,PLAINVILLE,United States Senator,,REP,KAREN C. HANDEL,19,0,2,0,21
+Gordon,SONORAVILLE,United States Senator,,REP,KAREN C. HANDEL,74,2,15,0,91
+Gordon,PINE CHAPEL,United States Senator,,REP,KAREN C. HANDEL,13,0,4,0,17
+Gordon,OOSTANAULA,United States Senator,,REP,KAREN C. HANDEL,19,0,5,0,24
+Gordon,OAKMAN,United States Senator,,REP,KAREN C. HANDEL,16,0,2,0,18
+Gordon,GORDON COUNTY,United States Senator,,REP,KAREN C. HANDEL,56,1,13,0,70
+Gordon,CALHOUN CITY,United States Senator,,REP,KAREN C. HANDEL,107,1,30,0,138
+Gordon,LILY POND,United States Senator,,REP,KAREN C. HANDEL,26,3,5,0,34
+Gordon,FAIRMOUNT,United States Senator,,REP,KAREN C. HANDEL,27,1,3,0,31
+Gordon,RED BUD,United States Senator,,REP,KAREN C. HANDEL,34,0,4,0,38
+Gordon,RESACA,United States Senator,,REP,KAREN C. HANDEL,24,0,2,0,26
+Gordon,,United States Senator,,REP,KAREN C. HANDEL,439,8,91,0,538
+Gordon,SUGAR VALLEY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",34,0,3,0,37
+Gordon,PLAINVILLE,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",27,1,2,0,30
+Gordon,SONORAVILLE,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",92,2,16,0,110
+Gordon,PINE CHAPEL,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",23,0,0,0,23
+Gordon,OOSTANAULA,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",13,0,0,0,13
+Gordon,OAKMAN,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",14,0,1,0,15
+Gordon,GORDON COUNTY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",64,0,23,0,87
+Gordon,CALHOUN CITY,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",99,1,25,0,125
+Gordon,LILY POND,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",30,1,4,0,35
+Gordon,FAIRMOUNT,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",33,0,3,0,36
+Gordon,RED BUD,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",40,0,7,0,47
+Gordon,RESACA,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",30,0,1,0,31
+Gordon,,United States Senator,,REP,"J.H. ""JACK"" KINGSTON",499,5,85,0,589
+Gordon,SUGAR VALLEY,United States Senator,,REP,DAVID A. PERDUE,64,1,5,0,70
+Gordon,PLAINVILLE,United States Senator,,REP,DAVID A. PERDUE,61,2,9,0,72
+Gordon,SONORAVILLE,United States Senator,,REP,DAVID A. PERDUE,210,1,29,0,240
+Gordon,PINE CHAPEL,United States Senator,,REP,DAVID A. PERDUE,39,0,8,0,47
+Gordon,OOSTANAULA,United States Senator,,REP,DAVID A. PERDUE,26,1,5,0,32
+Gordon,OAKMAN,United States Senator,,REP,DAVID A. PERDUE,40,0,7,1,48
+Gordon,GORDON COUNTY,United States Senator,,REP,DAVID A. PERDUE,186,5,53,0,244
+Gordon,CALHOUN CITY,United States Senator,,REP,DAVID A. PERDUE,229,11,95,1,336
+Gordon,LILY POND,United States Senator,,REP,DAVID A. PERDUE,80,0,19,0,99
+Gordon,FAIRMOUNT,United States Senator,,REP,DAVID A. PERDUE,99,3,13,1,116
+Gordon,RED BUD,United States Senator,,REP,DAVID A. PERDUE,94,3,12,0,109
+Gordon,RESACA,United States Senator,,REP,DAVID A. PERDUE,61,1,6,1,69
+Gordon,,United States Senator,,REP,DAVID A. PERDUE,1189,28,261,4,1482
+Gordon,SUGAR VALLEY,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1
+Gordon,PLAINVILLE,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1
+Gordon,SONORAVILLE,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,1,0,1
+Gordon,PINE CHAPEL,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0
+Gordon,OOSTANAULA,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0
+Gordon,OAKMAN,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0
+Gordon,GORDON COUNTY,United States Senator,,DEM,"O. ""STEEN"" MILES",0,0,0,0,0
+Gordon,CALHOUN CITY,United States Senator,,DEM,"O. ""STEEN"" MILES",3,0,2,0,5
+Gordon,LILY POND,United States Senator,,DEM,"O. ""STEEN"" MILES",2,0,0,0,2
+Gordon,FAIRMOUNT,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1
+Gordon,RED BUD,United States Senator,,DEM,"O. ""STEEN"" MILES",1,1,0,0,2
+Gordon,RESACA,United States Senator,,DEM,"O. ""STEEN"" MILES",1,0,0,0,1
+Gordon,,United States Senator,,DEM,"O. ""STEEN"" MILES",10,1,3,0,14
+Gordon,SUGAR VALLEY,United States Senator,,DEM,M. MICHELLE NUNN,12,0,0,0,12
+Gordon,PLAINVILLE,United States Senator,,DEM,M. MICHELLE NUNN,8,0,1,0,9
+Gordon,SONORAVILLE,United States Senator,,DEM,M. MICHELLE NUNN,29,7,12,0,48
+Gordon,PINE CHAPEL,United States Senator,,DEM,M. MICHELLE NUNN,10,0,5,0,15
+Gordon,OOSTANAULA,United States Senator,,DEM,M. MICHELLE NUNN,8,0,6,0,14
+Gordon,OAKMAN,United States Senator,,DEM,M. MICHELLE NUNN,18,0,1,0,19
+Gordon,GORDON COUNTY,United States Senator,,DEM,M. MICHELLE NUNN,37,4,10,1,52
+Gordon,CALHOUN CITY,United States Senator,,DEM,M. MICHELLE NUNN,63,11,26,0,100
+Gordon,LILY POND,United States Senator,,DEM,M. MICHELLE NUNN,12,1,2,0,15
+Gordon,FAIRMOUNT,United States Senator,,DEM,M. MICHELLE NUNN,8,1,2,0,11
+Gordon,RED BUD,United States Senator,,DEM,M. MICHELLE NUNN,20,0,7,0,27
+Gordon,RESACA,United States Senator,,DEM,M. MICHELLE NUNN,9,0,0,0,9
+Gordon,,United States Senator,,DEM,M. MICHELLE NUNN,234,24,72,1,331
+Gordon,SUGAR VALLEY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1
+Gordon,PLAINVILLE,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0
+Gordon,SONORAVILLE,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0
+Gordon,PINE CHAPEL,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1
+Gordon,OOSTANAULA,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,1,0,1
+Gordon,OAKMAN,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1
+Gordon,GORDON COUNTY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",2,0,0,0,2
+Gordon,CALHOUN CITY,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",5,1,1,0,7
+Gordon,LILY POND,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",1,0,0,0,1
+Gordon,FAIRMOUNT,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0
+Gordon,RED BUD,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",2,0,0,0,2
+Gordon,RESACA,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",0,0,0,0,0
+Gordon,,United States Senator,,DEM,"BRANKO ""RAD"" RADULOVACKI",13,1,2,0,16
+Gordon,SUGAR VALLEY,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,0,0,4
+Gordon,PLAINVILLE,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1
+Gordon,SONORAVILLE,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1
+Gordon,PINE CHAPEL,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1
+Gordon,OOSTANAULA,United States Senator,,DEM,TODD ANTHONY ROBINSON,0,0,0,0,0
+Gordon,OAKMAN,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,0,0,0,1
+Gordon,GORDON COUNTY,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,3,0,7
+Gordon,CALHOUN CITY,United States Senator,,DEM,TODD ANTHONY ROBINSON,1,1,3,0,5
+Gordon,LILY POND,United States Senator,,DEM,TODD ANTHONY ROBINSON,3,0,0,0,3
+Gordon,FAIRMOUNT,United States Senator,,DEM,TODD ANTHONY ROBINSON,0,1,0,0,1
+Gordon,RED BUD,United States Senator,,DEM,TODD ANTHONY ROBINSON,2,1,1,0,4
+Gordon,RESACA,United States Senator,,DEM,TODD ANTHONY ROBINSON,4,0,2,0,6
+Gordon,,United States Senator,,DEM,TODD ANTHONY ROBINSON,22,3,9,0,34
+Gordon,SUGAR VALLEY,Governor,,REP,JOHN D. BARGE,31,0,0,0,31
+Gordon,PLAINVILLE,Governor,,REP,JOHN D. BARGE,41,2,4,0,47
+Gordon,SONORAVILLE,Governor,,REP,JOHN D. BARGE,112,2,14,0,128
+Gordon,PINE CHAPEL,Governor,,REP,JOHN D. BARGE,9,0,3,0,12
+Gordon,OOSTANAULA,Governor,,REP,JOHN D. BARGE,10,0,3,0,13
+Gordon,OAKMAN,Governor,,REP,JOHN D. BARGE,23,0,3,0,26
+Gordon,GORDON COUNTY,Governor,,REP,JOHN D. BARGE,82,1,19,0,102
+Gordon,CALHOUN CITY,Governor,,REP,JOHN D. BARGE,127,1,42,0,170
+Gordon,LILY POND,Governor,,REP,JOHN D. BARGE,49,1,8,0,58
+Gordon,FAIRMOUNT,Governor,,REP,JOHN D. BARGE,38,1,5,0,44
+Gordon,RED BUD,Governor,,REP,JOHN D. BARGE,58,2,7,0,67
+Gordon,RESACA,Governor,,REP,JOHN D. BARGE,15,0,0,0,15
+Gordon,,Governor,,REP,JOHN D. BARGE,595,10,108,0,713
+Gordon,SUGAR VALLEY,Governor,,REP,J. NATHAN DEAL (I),85,2,16,0,103
+Gordon,PLAINVILLE,Governor,,REP,J. NATHAN DEAL (I),96,2,11,0,109
+Gordon,SONORAVILLE,Governor,,REP,J. NATHAN DEAL (I),358,7,68,0,433
+Gordon,PINE CHAPEL,Governor,,REP,J. NATHAN DEAL (I),83,0,11,0,94
+Gordon,OOSTANAULA,Governor,,REP,J. NATHAN DEAL (I),56,3,9,0,68
+Gordon,OAKMAN,Governor,,REP,J. NATHAN DEAL (I),66,0,7,1,74
+Gordon,GORDON COUNTY,Governor,,REP,J. NATHAN DEAL (I),268,10,104,0,382
+Gordon,CALHOUN CITY,Governor,,REP,J. NATHAN DEAL (I),374,17,162,1,554
+Gordon,LILY POND,Governor,,REP,J. NATHAN DEAL (I),120,4,30,0,154
+Gordon,FAIRMOUNT,Governor,,REP,J. NATHAN DEAL (I),150,0,12,1,163
+Gordon,RED BUD,Governor,,REP,J. NATHAN DEAL (I),144,5,32,0,181
+Gordon,RESACA,Governor,,REP,J. NATHAN DEAL (I),111,2,12,1,126
+Gordon,,Governor,,REP,J. NATHAN DEAL (I),1911,52,474,4,2441
+Gordon,SUGAR VALLEY,Governor,,REP,DAVID E. PENNINGTON III,55,0,6,0,61
+Gordon,PLAINVILLE,Governor,,REP,DAVID E. PENNINGTON III,39,2,2,0,43
+Gordon,SONORAVILLE,Governor,,REP,DAVID E. PENNINGTON III,92,0,7,0,99
+Gordon,PINE CHAPEL,Governor,,REP,DAVID E. PENNINGTON III,18,0,1,0,19
+Gordon,OOSTANAULA,Governor,,REP,DAVID E. PENNINGTON III,19,1,1,0,21
+Gordon,OAKMAN,Governor,,REP,DAVID E. PENNINGTON III,20,1,1,0,22
+Gordon,GORDON COUNTY,Governor,,REP,DAVID E. PENNINGTON III,118,1,19,1,139
+Gordon,CALHOUN CITY,Governor,,REP,DAVID E. PENNINGTON III,157,6,47,0,210
+Gordon,LILY POND,Governor,,REP,DAVID E. PENNINGTON III,35,0,7,0,42
+Gordon,FAIRMOUNT,Governor,,REP,DAVID E. PENNINGTON III,41,2,7,0,50
+Gordon,RED BUD,Governor,,REP,DAVID E. PENNINGTON III,58,2,2,0,62
+Gordon,RESACA,Governor,,REP,DAVID E. PENNINGTON III,39,0,3,0,42
+Gordon,,Governor,,REP,DAVID E. PENNINGTON III,691,15,103,1,810
+Gordon,SUGAR VALLEY,Governor,,DEM,JASON J. CARTER,19,0,0,0,19
+Gordon,PLAINVILLE,Governor,,DEM,JASON J. CARTER,9,0,1,0,10
+Gordon,SONORAVILLE,Governor,,DEM,JASON J. CARTER,25,7,12,0,44
+Gordon,PINE CHAPEL,Governor,,DEM,JASON J. CARTER,12,0,5,0,17
+Gordon,OOSTANAULA,Governor,,DEM,JASON J. CARTER,8,0,7,0,15
+Gordon,OAKMAN,Governor,,DEM,JASON J. CARTER,19,0,1,0,20
+Gordon,GORDON COUNTY,Governor,,DEM,JASON J. CARTER,42,4,12,1,59
+Gordon,CALHOUN CITY,Governor,,DEM,JASON J. CARTER,69,14,27,0,110
+Gordon,LILY POND,Governor,,DEM,JASON J. CARTER,16,1,3,0,20
+Gordon,FAIRMOUNT,Governor,,DEM,JASON J. CARTER,7,2,1,0,10
+Gordon,RED BUD,Governor,,DEM,JASON J. CARTER,23,3,6,0,32
+Gordon,RESACA,Governor,,DEM,JASON J. CARTER,14,0,2,0,16
+Gordon,,Governor,,DEM,JASON J. CARTER,263,31,77,1,372
+Gordon,SUGAR VALLEY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",134,2,16,0,152
+Gordon,PLAINVILLE,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",131,3,8,0,142
+Gordon,SONORAVILLE,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",445,8,66,0,519
+Gordon,PINE CHAPEL,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",84,0,11,0,95
+Gordon,OOSTANAULA,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",68,4,12,0,84
+Gordon,OAKMAN,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",77,1,7,1,86
+Gordon,GORDON COUNTY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",370,12,116,1,499
+Gordon,CALHOUN CITY,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",509,18,185,1,713
+Gordon,LILY POND,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",145,5,37,0,187
+Gordon,FAIRMOUNT,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",187,2,18,1,208
+Gordon,RED BUD,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",198,7,38,0,243
+Gordon,RESACA,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",124,1,13,1,139
+Gordon,,Lieutenant Governor,,REP,"L. S. ""CASEY"" CAGLE (I)",2472,63,527,5,3067
+Gordon,SUGAR VALLEY,Lieutenant Governor,,DEM,CONNIE J. STOKES,15,0,0,0,15
+Gordon,PLAINVILLE,Lieutenant Governor,,DEM,CONNIE J. STOKES,7,0,1,0,8
+Gordon,SONORAVILLE,Lieutenant Governor,,DEM,CONNIE J. STOKES,24,5,7,0,36
+Gordon,PINE CHAPEL,Lieutenant Governor,,DEM,CONNIE J. STOKES,8,0,4,0,12
+Gordon,OOSTANAULA,Lieutenant Governor,,DEM,CONNIE J. STOKES,7,0,5,0,12
+Gordon,OAKMAN,Lieutenant Governor,,DEM,CONNIE J. STOKES,15,0,1,0,16
+Gordon,GORDON COUNTY,Lieutenant Governor,,DEM,CONNIE J. STOKES,30,4,9,1,44
+Gordon,CALHOUN CITY,Lieutenant Governor,,DEM,CONNIE J. STOKES,57,10,25,0,92
+Gordon,LILY POND,Lieutenant Governor,,DEM,CONNIE J. STOKES,12,1,2,0,15
+Gordon,FAIRMOUNT,Lieutenant Governor,,DEM,CONNIE J. STOKES,8,2,1,0,11
+Gordon,RED BUD,Lieutenant Governor,,DEM,CONNIE J. STOKES,22,2,6,0,30
+Gordon,RESACA,Lieutenant Governor,,DEM,CONNIE J. STOKES,10,0,2,0,12
+Gordon,,Lieutenant Governor,,DEM,CONNIE J. STOKES,215,24,63,1,303
+Gordon,SUGAR VALLEY,Secretary Of State,,REP,BRIAN P. KEMP (I),128,2,14,0,144
+Gordon,PLAINVILLE,Secretary Of State,,REP,BRIAN P. KEMP (I),129,3,8,0,140
+Gordon,SONORAVILLE,Secretary Of State,,REP,BRIAN P. KEMP (I),418,7,64,0,489
+Gordon,PINE CHAPEL,Secretary Of State,,REP,BRIAN P. KEMP (I),77,0,11,0,88
+Gordon,OOSTANAULA,Secretary Of State,,REP,BRIAN P. KEMP (I),58,4,11,0,73
+Gordon,OAKMAN,Secretary Of State,,REP,BRIAN P. KEMP (I),74,1,7,1,83
+Gordon,GORDON COUNTY,Secretary Of State,,REP,BRIAN P. KEMP (I),355,12,105,1,473
+Gordon,CALHOUN CITY,Secretary Of State,,REP,BRIAN P. KEMP (I),499,16,174,1,690
+Gordon,LILY POND,Secretary Of State,,REP,BRIAN P. KEMP (I),137,4,37,0,178
+Gordon,FAIRMOUNT,Secretary Of State,,REP,BRIAN P. KEMP (I),179,2,17,1,199
+Gordon,RED BUD,Secretary Of State,,REP,BRIAN P. KEMP (I),193,6,35,0,234
+Gordon,RESACA,Secretary Of State,,REP,BRIAN P. KEMP (I),113,1,11,1,126
+Gordon,,Secretary Of State,,REP,BRIAN P. KEMP (I),2360,58,494,5,2917
+Gordon,SUGAR VALLEY,Secretary Of State,,DEM,GERALD B. BECKUM,3,0,0,0,3
+Gordon,PLAINVILLE,Secretary Of State,,DEM,GERALD B. BECKUM,1,0,1,0,2
+Gordon,SONORAVILLE,Secretary Of State,,DEM,GERALD B. BECKUM,12,0,2,0,14
+Gordon,PINE CHAPEL,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,1,0,5
+Gordon,OOSTANAULA,Secretary Of State,,DEM,GERALD B. BECKUM,3,0,2,0,5
+Gordon,OAKMAN,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,0,0,4
+Gordon,GORDON COUNTY,Secretary Of State,,DEM,GERALD B. BECKUM,11,2,5,0,18
+Gordon,CALHOUN CITY,Secretary Of State,,DEM,GERALD B. BECKUM,15,6,6,0,27
+Gordon,LILY POND,Secretary Of State,,DEM,GERALD B. BECKUM,2,0,1,0,3
+Gordon,FAIRMOUNT,Secretary Of State,,DEM,GERALD B. BECKUM,4,2,0,0,6
+Gordon,RED BUD,Secretary Of State,,DEM,GERALD B. BECKUM,6,1,4,0,11
+Gordon,RESACA,Secretary Of State,,DEM,GERALD B. BECKUM,4,0,1,0,5
+Gordon,,Secretary Of State,,DEM,GERALD B. BECKUM,69,11,23,0,103
+Gordon,SUGAR VALLEY,Secretary Of State,,DEM,DOREEN CARTER,14,0,0,0,14
+Gordon,PLAINVILLE,Secretary Of State,,DEM,DOREEN CARTER,9,0,0,0,9
+Gordon,SONORAVILLE,Secretary Of State,,DEM,DOREEN CARTER,14,7,11,0,32
+Gordon,PINE CHAPEL,Secretary Of State,,DEM,DOREEN CARTER,5,0,4,0,9
+Gordon,OOSTANAULA,Secretary Of State,,DEM,DOREEN CARTER,4,0,5,0,9
+Gordon,OAKMAN,Secretary Of State,,DEM,DOREEN CARTER,13,0,1,0,14
+Gordon,GORDON COUNTY,Secretary Of State,,DEM,DOREEN CARTER,27,2,7,1,37
+Gordon,CALHOUN CITY,Secretary Of State,,DEM,DOREEN CARTER,49,7,17,0,73
+Gordon,LILY POND,Secretary Of State,,DEM,DOREEN CARTER,12,1,2,0,15
+Gordon,FAIRMOUNT,Secretary Of State,,DEM,DOREEN CARTER,4,0,1,0,5
+Gordon,RED BUD,Secretary Of State,,DEM,DOREEN CARTER,16,1,4,0,21
+Gordon,RESACA,Secretary Of State,,DEM,DOREEN CARTER,9,0,1,0,10
+Gordon,,Secretary Of State,,DEM,DOREEN CARTER,176,18,53,1,248
+Gordon,SUGAR VALLEY,Attorney General,,REP,SAMUEL S. OLENS (I),121,1,15,0,137
+Gordon,PLAINVILLE,Attorney General,,REP,SAMUEL S. OLENS (I),123,2,8,0,133
+Gordon,SONORAVILLE,Attorney General,,REP,SAMUEL S. OLENS (I),394,7,58,0,459
+Gordon,PINE CHAPEL,Attorney General,,REP,SAMUEL S. OLENS (I),72,0,9,0,81
+Gordon,OOSTANAULA,Attorney General,,REP,SAMUEL S. OLENS (I),51,4,11,0,66
+Gordon,OAKMAN,Attorney General,,REP,SAMUEL S. OLENS (I),74,1,5,1,81
+Gordon,GORDON COUNTY,Attorney General,,REP,SAMUEL S. OLENS (I),327,12,97,1,437
+Gordon,CALHOUN CITY,Attorney General,,REP,SAMUEL S. OLENS (I),455,17,166,1,639
+Gordon,LILY POND,Attorney General,,REP,SAMUEL S. OLENS (I),130,4,32,0,166
+Gordon,FAIRMOUNT,Attorney General,,REP,SAMUEL S. OLENS (I),161,2,14,1,178
+Gordon,RED BUD,Attorney General,,REP,SAMUEL S. OLENS (I),182,7,35,0,224
+Gordon,RESACA,Attorney General,,REP,SAMUEL S. OLENS (I),114,1,10,1,126
+Gordon,,Attorney General,,REP,SAMUEL S. OLENS (I),2204,58,460,5,2727
+Gordon,SUGAR VALLEY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",14,0,0,0,14
+Gordon,PLAINVILLE,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,0,1,0,9
+Gordon,SONORAVILLE,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",24,6,12,0,42
+Gordon,PINE CHAPEL,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,0,4,0,12
+Gordon,OOSTANAULA,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",6,0,7,0,13
+Gordon,OAKMAN,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",16,0,0,0,16
+Gordon,GORDON COUNTY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",31,4,11,1,47
+Gordon,CALHOUN CITY,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",56,12,21,0,89
+Gordon,LILY POND,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",11,1,3,0,15
+Gordon,FAIRMOUNT,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",8,1,1,0,10
+Gordon,RED BUD,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",21,2,6,0,29
+Gordon,RESACA,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",10,0,2,0,12
+Gordon,,Attorney General,,DEM,"GREGORY K. ""GREG"" HECHT",213,26,68,1,308
+Gordon,SUGAR VALLEY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),132,1,17,0,150
+Gordon,PLAINVILLE,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),132,2,8,0,142
+Gordon,SONORAVILLE,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),428,8,65,0,501
+Gordon,PINE CHAPEL,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),79,0,11,0,90
+Gordon,OOSTANAULA,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),59,4,9,0,72
+Gordon,OAKMAN,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),81,1,7,1,90
+Gordon,GORDON COUNTY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),347,11,103,1,462
+Gordon,CALHOUN CITY,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),469,17,166,1,653
+Gordon,LILY POND,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),141,4,37,0,182
+Gordon,FAIRMOUNT,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),179,3,15,1,198
+Gordon,RED BUD,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),190,7,36,0,233
+Gordon,RESACA,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),123,1,11,1,136
+Gordon,,Commissioner Of Agriculture,,REP,GARY W. BLACK (I),2360,59,485,5,2909
+Gordon,SUGAR VALLEY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,17,0,0,0,17
+Gordon,PLAINVILLE,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,0,1,0,9
+Gordon,SONORAVILLE,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,23,6,9,0,38
+Gordon,PINE CHAPEL,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,0,4,0,12
+Gordon,OOSTANAULA,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,7,0,6,0,13
+Gordon,OAKMAN,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,15,0,1,0,16
+Gordon,GORDON COUNTY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,33,4,11,1,49
+Gordon,CALHOUN CITY,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,57,13,22,0,92
+Gordon,LILY POND,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,12,1,2,0,15
+Gordon,FAIRMOUNT,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,8,2,1,0,11
+Gordon,RED BUD,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,23,3,6,0,32
+Gordon,RESACA,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,13,0,2,0,15
+Gordon,,Commissioner Of Agriculture,,DEM,CHRISTOPHER J. IRVIN,224,29,65,1,319
+Gordon,SUGAR VALLEY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),116,1,14,0,131
+Gordon,PLAINVILLE,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),122,2,9,0,133
+Gordon,SONORAVILLE,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),405,7,59,0,471
+Gordon,PINE CHAPEL,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),71,0,10,0,81
+Gordon,OOSTANAULA,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),51,4,11,0,66
+Gordon,OAKMAN,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),75,1,5,1,82
+Gordon,GORDON COUNTY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),323,11,96,1,431
+Gordon,CALHOUN CITY,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),440,17,159,1,617
+Gordon,LILY POND,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),132,3,32,0,167
+Gordon,FAIRMOUNT,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),161,3,13,1,178
+Gordon,RED BUD,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),175,7,34,0,216
+Gordon,RESACA,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),116,1,10,1,128
+Gordon,,Commissioner Of Insurance,,REP,RALPH T. HUDGENS (I),2187,57,452,5,2701
+Gordon,SUGAR VALLEY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,5,0,0,0,5
+Gordon,PLAINVILLE,Commissioner Of Insurance,,DEM,KEITH G. HEARD,2,0,0,0,2
+Gordon,SONORAVILLE,Commissioner Of Insurance,,DEM,KEITH G. HEARD,9,2,0,0,11
+Gordon,PINE CHAPEL,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,1,0,4
+Gordon,OOSTANAULA,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,1,0,4
+Gordon,OAKMAN,Commissioner Of Insurance,,DEM,KEITH G. HEARD,4,0,0,0,4
+Gordon,GORDON COUNTY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,16,3,3,0,22
+Gordon,CALHOUN CITY,Commissioner Of Insurance,,DEM,KEITH G. HEARD,8,5,7,0,20
+Gordon,LILY POND,Commissioner Of Insurance,,DEM,KEITH G. HEARD,6,0,0,0,6
+Gordon,FAIRMOUNT,Commissioner Of Insurance,,DEM,KEITH G. HEARD,3,0,0,0,3
+Gordon,RED BUD,Commissioner Of Insurance,,DEM,KEITH G. HEARD,8,1,3,0,12
+Gordon,RESACA,Commissioner Of Insurance,,DEM,KEITH G. HEARD,5,0,0,0,5
+Gordon,,Commissioner Of Insurance,,DEM,KEITH G. HEARD,72,11,15,0,98
+Gordon,SUGAR VALLEY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",14,0,0,0,14
+Gordon,PLAINVILLE,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",8,0,0,0,8
+Gordon,SONORAVILLE,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",19,5,13,0,37
+Gordon,PINE CHAPEL,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",5,0,4,0,9
+Gordon,OOSTANAULA,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",4,0,6,0,10
+Gordon,OAKMAN,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",12,0,1,0,13
+Gordon,GORDON COUNTY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",23,1,10,1,35
+Gordon,CALHOUN CITY,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",49,8,16,0,73
+Gordon,LILY POND,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",8,1,3,0,12
+Gordon,FAIRMOUNT,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",6,2,1,0,9
+Gordon,RED BUD,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",13,1,5,0,19
+Gordon,RESACA,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",7,0,2,0,9
+Gordon,,Commissioner Of Insurance,,DEM,"ELIZABETH N. ""LIZ"" JOHNSON",168,18,61,1,248
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,MARY KAY BACALLAO,15,0,1,0,16
+Gordon,PLAINVILLE,State School Superintendent,,REP,MARY KAY BACALLAO,14,0,1,0,15
+Gordon,SONORAVILLE,State School Superintendent,,REP,MARY KAY BACALLAO,71,1,10,0,82
+Gordon,PINE CHAPEL,State School Superintendent,,REP,MARY KAY BACALLAO,12,0,0,0,12
+Gordon,OOSTANAULA,State School Superintendent,,REP,MARY KAY BACALLAO,12,2,0,0,14
+Gordon,OAKMAN,State School Superintendent,,REP,MARY KAY BACALLAO,11,0,2,0,13
+Gordon,GORDON COUNTY,State School Superintendent,,REP,MARY KAY BACALLAO,48,1,14,0,63
+Gordon,CALHOUN CITY,State School Superintendent,,REP,MARY KAY BACALLAO,57,1,24,0,82
+Gordon,LILY POND,State School Superintendent,,REP,MARY KAY BACALLAO,25,0,7,0,32
+Gordon,FAIRMOUNT,State School Superintendent,,REP,MARY KAY BACALLAO,17,0,1,0,18
+Gordon,RED BUD,State School Superintendent,,REP,MARY KAY BACALLAO,28,0,1,0,29
+Gordon,RESACA,State School Superintendent,,REP,MARY KAY BACALLAO,15,0,2,0,17
+Gordon,,State School Superintendent,,REP,MARY KAY BACALLAO,325,5,63,0,393
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,ASHLEY D. BELL,15,0,1,0,16
+Gordon,PLAINVILLE,State School Superintendent,,REP,ASHLEY D. BELL,17,0,1,0,18
+Gordon,SONORAVILLE,State School Superintendent,,REP,ASHLEY D. BELL,42,2,7,0,51
+Gordon,PINE CHAPEL,State School Superintendent,,REP,ASHLEY D. BELL,12,0,1,0,13
+Gordon,OOSTANAULA,State School Superintendent,,REP,ASHLEY D. BELL,10,0,1,0,11
+Gordon,OAKMAN,State School Superintendent,,REP,ASHLEY D. BELL,9,1,1,0,11
+Gordon,GORDON COUNTY,State School Superintendent,,REP,ASHLEY D. BELL,38,0,7,0,45
+Gordon,CALHOUN CITY,State School Superintendent,,REP,ASHLEY D. BELL,40,0,11,0,51
+Gordon,LILY POND,State School Superintendent,,REP,ASHLEY D. BELL,15,0,3,0,18
+Gordon,FAIRMOUNT,State School Superintendent,,REP,ASHLEY D. BELL,24,0,2,0,26
+Gordon,RED BUD,State School Superintendent,,REP,ASHLEY D. BELL,17,0,1,0,18
+Gordon,RESACA,State School Superintendent,,REP,ASHLEY D. BELL,17,0,0,0,17
+Gordon,,State School Superintendent,,REP,ASHLEY D. BELL,256,3,36,0,295
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",12,1,2,0,15
+Gordon,PLAINVILLE,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",27,0,1,0,28
+Gordon,SONORAVILLE,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",62,1,10,0,73
+Gordon,PINE CHAPEL,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",8,0,4,0,12
+Gordon,OOSTANAULA,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",7,0,3,0,10
+Gordon,OAKMAN,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",10,0,0,0,10
+Gordon,GORDON COUNTY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",51,1,13,0,65
+Gordon,CALHOUN CITY,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",72,4,33,0,109
+Gordon,LILY POND,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",18,2,3,0,23
+Gordon,FAIRMOUNT,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",21,0,4,1,26
+Gordon,RED BUD,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",26,0,7,0,33
+Gordon,RESACA,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",18,1,1,0,20
+Gordon,,State School Superintendent,,REP,"MICHAEL L. ""MIKE"" BUCK",332,10,81,1,424
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,SHARYL H. DAWES,7,0,0,0,7
+Gordon,PLAINVILLE,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3
+Gordon,SONORAVILLE,State School Superintendent,,REP,SHARYL H. DAWES,9,0,1,0,10
+Gordon,PINE CHAPEL,State School Superintendent,,REP,SHARYL H. DAWES,1,0,1,0,2
+Gordon,OOSTANAULA,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3
+Gordon,OAKMAN,State School Superintendent,,REP,SHARYL H. DAWES,3,0,0,0,3
+Gordon,GORDON COUNTY,State School Superintendent,,REP,SHARYL H. DAWES,15,0,5,0,20
+Gordon,CALHOUN CITY,State School Superintendent,,REP,SHARYL H. DAWES,22,0,4,0,26
+Gordon,LILY POND,State School Superintendent,,REP,SHARYL H. DAWES,6,0,1,0,7
+Gordon,FAIRMOUNT,State School Superintendent,,REP,SHARYL H. DAWES,5,0,1,0,6
+Gordon,RED BUD,State School Superintendent,,REP,SHARYL H. DAWES,6,1,0,0,7
+Gordon,RESACA,State School Superintendent,,REP,SHARYL H. DAWES,5,0,0,0,5
+Gordon,,State School Superintendent,,REP,SHARYL H. DAWES,85,1,13,0,99
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,ALLEN BOWLES FORT,48,0,9,0,57
+Gordon,PLAINVILLE,State School Superintendent,,REP,ALLEN BOWLES FORT,50,4,6,0,60
+Gordon,SONORAVILLE,State School Superintendent,,REP,ALLEN BOWLES FORT,183,4,24,0,211
+Gordon,PINE CHAPEL,State School Superintendent,,REP,ALLEN BOWLES FORT,29,0,4,0,33
+Gordon,OOSTANAULA,State School Superintendent,,REP,ALLEN BOWLES FORT,24,1,7,0,32
+Gordon,OAKMAN,State School Superintendent,,REP,ALLEN BOWLES FORT,30,0,5,0,35
+Gordon,GORDON COUNTY,State School Superintendent,,REP,ALLEN BOWLES FORT,136,4,38,1,179
+Gordon,CALHOUN CITY,State School Superintendent,,REP,ALLEN BOWLES FORT,255,9,99,0,363
+Gordon,LILY POND,State School Superintendent,,REP,ALLEN BOWLES FORT,66,2,18,0,86
+Gordon,FAIRMOUNT,State School Superintendent,,REP,ALLEN BOWLES FORT,77,3,9,0,89
+Gordon,RED BUD,State School Superintendent,,REP,ALLEN BOWLES FORT,103,1,19,0,123
+Gordon,RESACA,State School Superintendent,,REP,ALLEN BOWLES FORT,38,0,6,1,45
+Gordon,,State School Superintendent,,REP,ALLEN BOWLES FORT,1039,28,244,2,1313
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,NANCY T. JESTER,10,0,0,0,10
+Gordon,PLAINVILLE,State School Superintendent,,REP,NANCY T. JESTER,14,0,1,0,15
+Gordon,SONORAVILLE,State School Superintendent,,REP,NANCY T. JESTER,19,1,2,0,22
+Gordon,PINE CHAPEL,State School Superintendent,,REP,NANCY T. JESTER,3,0,2,0,5
+Gordon,OOSTANAULA,State School Superintendent,,REP,NANCY T. JESTER,6,0,0,0,6
+Gordon,OAKMAN,State School Superintendent,,REP,NANCY T. JESTER,3,0,1,0,4
+Gordon,GORDON COUNTY,State School Superintendent,,REP,NANCY T. JESTER,15,0,10,0,25
+Gordon,CALHOUN CITY,State School Superintendent,,REP,NANCY T. JESTER,17,1,8,0,26
+Gordon,LILY POND,State School Superintendent,,REP,NANCY T. JESTER,6,0,1,0,7
+Gordon,FAIRMOUNT,State School Superintendent,,REP,NANCY T. JESTER,7,0,2,0,9
+Gordon,RED BUD,State School Superintendent,,REP,NANCY T. JESTER,8,0,1,0,9
+Gordon,RESACA,State School Superintendent,,REP,NANCY T. JESTER,10,0,0,0,10
+Gordon,,State School Superintendent,,REP,NANCY T. JESTER,118,2,28,0,148
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,T. FITZ JOHNSON,9,0,1,0,10
+Gordon,PLAINVILLE,State School Superintendent,,REP,T. FITZ JOHNSON,4,0,2,0,6
+Gordon,SONORAVILLE,State School Superintendent,,REP,T. FITZ JOHNSON,27,0,4,0,31
+Gordon,PINE CHAPEL,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,0,0,7
+Gordon,OOSTANAULA,State School Superintendent,,REP,T. FITZ JOHNSON,3,0,0,0,3
+Gordon,OAKMAN,State School Superintendent,,REP,T. FITZ JOHNSON,10,0,0,0,10
+Gordon,GORDON COUNTY,State School Superintendent,,REP,T. FITZ JOHNSON,24,0,4,0,28
+Gordon,CALHOUN CITY,State School Superintendent,,REP,T. FITZ JOHNSON,20,0,4,0,24
+Gordon,LILY POND,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,1,0,8
+Gordon,FAIRMOUNT,State School Superintendent,,REP,T. FITZ JOHNSON,14,0,0,0,14
+Gordon,RED BUD,State School Superintendent,,REP,T. FITZ JOHNSON,4,2,0,0,6
+Gordon,RESACA,State School Superintendent,,REP,T. FITZ JOHNSON,7,0,0,0,7
+Gordon,,State School Superintendent,,REP,T. FITZ JOHNSON,136,2,16,0,154
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,KIRA G. WILLIS,3,0,0,0,3
+Gordon,PLAINVILLE,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,0,2
+Gordon,SONORAVILLE,State School Superintendent,,REP,KIRA G. WILLIS,6,0,0,0,6
+Gordon,PINE CHAPEL,State School Superintendent,,REP,KIRA G. WILLIS,0,0,0,0,0
+Gordon,OOSTANAULA,State School Superintendent,,REP,KIRA G. WILLIS,3,0,0,0,3
+Gordon,OAKMAN,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,1,3
+Gordon,GORDON COUNTY,State School Superintendent,,REP,KIRA G. WILLIS,9,0,4,0,13
+Gordon,CALHOUN CITY,State School Superintendent,,REP,KIRA G. WILLIS,14,0,2,0,16
+Gordon,LILY POND,State School Superintendent,,REP,KIRA G. WILLIS,6,0,0,0,6
+Gordon,FAIRMOUNT,State School Superintendent,,REP,KIRA G. WILLIS,4,0,0,0,4
+Gordon,RED BUD,State School Superintendent,,REP,KIRA G. WILLIS,2,0,0,0,2
+Gordon,RESACA,State School Superintendent,,REP,KIRA G. WILLIS,1,0,0,0,1
+Gordon,,State School Superintendent,,REP,KIRA G. WILLIS,52,0,6,1,59
+Gordon,SUGAR VALLEY,State School Superintendent,,REP,RICHARD L. WOODS,22,1,1,0,24
+Gordon,PLAINVILLE,State School Superintendent,,REP,RICHARD L. WOODS,23,0,2,0,25
+Gordon,SONORAVILLE,State School Superintendent,,REP,RICHARD L. WOODS,57,0,12,0,69
+Gordon,PINE CHAPEL,State School Superintendent,,REP,RICHARD L. WOODS,16,0,1,0,17
+Gordon,OOSTANAULA,State School Superintendent,,REP,RICHARD L. WOODS,8,1,0,0,9
+Gordon,OAKMAN,State School Superintendent,,REP,RICHARD L. WOODS,20,0,0,0,20
+Gordon,GORDON COUNTY,State School Superintendent,,REP,RICHARD L. WOODS,54,4,23,0,81
+Gordon,CALHOUN CITY,State School Superintendent,,REP,RICHARD L. WOODS,46,3,26,1,76
+Gordon,LILY POND,State School Superintendent,,REP,RICHARD L. WOODS,19,0,4,0,23
+Gordon,FAIRMOUNT,State School Superintendent,,REP,RICHARD L. WOODS,23,0,3,0,26
+Gordon,RED BUD,State School Superintendent,,REP,RICHARD L. WOODS,24,3,3,0,30
+Gordon,RESACA,State School Superintendent,,REP,RICHARD L. WOODS,23,0,3,0,26
+Gordon,,State School Superintendent,,REP,RICHARD L. WOODS,335,12,78,1,426
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2
+Gordon,PLAINVILLE,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1
+Gordon,SONORAVILLE,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,1,0,2
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2
+Gordon,OOSTANAULA,State School Superintendent,,DEM,TARNISHA L. DENT,0,0,2,0,2
+Gordon,OAKMAN,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,1,0,2
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,TARNISHA L. DENT,7,1,3,0,11
+Gordon,LILY POND,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,TARNISHA L. DENT,2,0,0,0,2
+Gordon,RED BUD,State School Superintendent,,DEM,TARNISHA L. DENT,3,0,4,0,7
+Gordon,RESACA,State School Superintendent,,DEM,TARNISHA L. DENT,1,0,0,0,1
+Gordon,,State School Superintendent,,DEM,TARNISHA L. DENT,23,1,11,0,35
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,0,0,2
+Gordon,PLAINVILLE,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,0,0,0
+Gordon,SONORAVILLE,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",1,0,0,0,1
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,2,0,4
+Gordon,OOSTANAULA,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",2,0,0,0,2
+Gordon,OAKMAN,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,0,0,0,3
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",14,2,2,1,19
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",10,3,7,0,20
+Gordon,LILY POND,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,1,1,0,5
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,0,0,0
+Gordon,RED BUD,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",3,0,1,0,4
+Gordon,RESACA,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",0,0,1,0,1
+Gordon,,State School Superintendent,,DEM,"MARION SPENCER ""DENISE"" FREEMAN",40,6,14,1,61
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0
+Gordon,PLAINVILLE,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0
+Gordon,SONORAVILLE,State School Superintendent,,DEM,JURITA FOREHAND MAYS,4,0,1,0,5
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,JURITA FOREHAND MAYS,2,0,0,0,2
+Gordon,OOSTANAULA,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0
+Gordon,OAKMAN,State School Superintendent,,DEM,JURITA FOREHAND MAYS,1,0,0,0,1
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,4,0,3,0,7
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,JURITA FOREHAND MAYS,5,0,1,0,6
+Gordon,LILY POND,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,JURITA FOREHAND MAYS,0,0,0,0,0
+Gordon,RED BUD,State School Superintendent,,DEM,JURITA FOREHAND MAYS,2,0,0,0,2
+Gordon,RESACA,State School Superintendent,,DEM,JURITA FOREHAND MAYS,1,0,0,0,1
+Gordon,,State School Superintendent,,DEM,JURITA FOREHAND MAYS,19,0,5,0,24
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
+Gordon,PLAINVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
+Gordon,SONORAVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,4,5,6,0,15
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,1,0,2
+Gordon,OOSTANAULA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,3,0,6
+Gordon,OAKMAN,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,0,0,0,6
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,1,4,0,11
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,10,3,4,0,17
+Gordon,LILY POND,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,1,0,3
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
+Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3
+Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,2,0,0,0,2
+Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,43,9,19,0,71
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,0,0,0,3
+Gordon,PLAINVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
+Gordon,SONORAVILLE,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
+Gordon,OOSTANAULA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
+Gordon,OAKMAN,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,6,1,0,0,7
+Gordon,LILY POND,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,3,1,0,0,4
+Gordon,RED BUD,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,0,0,0,0,0
+Gordon,RESACA,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,1,0,0,0,1
+Gordon,,State School Superintendent,,DEM,ALISHA THOMAS MORGAN,17,2,0,0,19
+Gordon,SUGAR VALLEY,State School Superintendent,,DEM,VALARIE D. WILSON,3,0,0,0,3
+Gordon,PLAINVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,0,0,5
+Gordon,SONORAVILLE,State School Superintendent,,DEM,VALARIE D. WILSON,13,2,5,0,20
+Gordon,PINE CHAPEL,State School Superintendent,,DEM,VALARIE D. WILSON,0,0,2,0,2
+Gordon,OOSTANAULA,State School Superintendent,,DEM,VALARIE D. WILSON,2,0,2,0,4
+Gordon,OAKMAN,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,1,0,6
+Gordon,GORDON COUNTY,State School Superintendent,,DEM,VALARIE D. WILSON,13,1,2,0,16
+Gordon,CALHOUN CITY,State School Superintendent,,DEM,VALARIE D. WILSON,21,4,7,0,32
+Gordon,LILY POND,State School Superintendent,,DEM,VALARIE D. WILSON,7,0,1,0,8
+Gordon,FAIRMOUNT,State School Superintendent,,DEM,VALARIE D. WILSON,1,1,1,0,3
+Gordon,RED BUD,State School Superintendent,,DEM,VALARIE D. WILSON,8,2,1,0,11
+Gordon,RESACA,State School Superintendent,,DEM,VALARIE D. WILSON,5,0,1,0,6
+Gordon,,State School Superintendent,,DEM,VALARIE D. WILSON,83,10,23,0,116
+Gordon,SUGAR VALLEY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),114,1,16,0,131
+Gordon,PLAINVILLE,Commissioner Of Labor,,REP,J. MARK BUTLER (I),122,2,7,0,131
+Gordon,SONORAVILLE,Commissioner Of Labor,,REP,J. MARK BUTLER (I),396,7,60,0,463
+Gordon,PINE CHAPEL,Commissioner Of Labor,,REP,J. MARK BUTLER (I),70,0,10,0,80
+Gordon,OOSTANAULA,Commissioner Of Labor,,REP,J. MARK BUTLER (I),48,4,12,0,64
+Gordon,OAKMAN,Commissioner Of Labor,,REP,J. MARK BUTLER (I),80,1,6,1,88
+Gordon,GORDON COUNTY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),322,12,94,1,429
+Gordon,CALHOUN CITY,Commissioner Of Labor,,REP,J. MARK BUTLER (I),438,16,161,1,616
+Gordon,LILY POND,Commissioner Of Labor,,REP,J. MARK BUTLER (I),128,3,32,0,163
+Gordon,FAIRMOUNT,Commissioner Of Labor,,REP,J. MARK BUTLER (I),162,2,14,1,179
+Gordon,RED BUD,Commissioner Of Labor,,REP,J. MARK BUTLER (I),175,7,35,0,217
+Gordon,RESACA,Commissioner Of Labor,,REP,J. MARK BUTLER (I),115,1,10,1,127
+Gordon,,Commissioner Of Labor,,REP,J. MARK BUTLER (I),2170,56,457,5,2688
+Gordon,SUGAR VALLEY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,13,0,0,0,13
+Gordon,PLAINVILLE,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,6,0,0,0,6
+Gordon,SONORAVILLE,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,23,6,11,0,40
+Gordon,PINE CHAPEL,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,9,0,4,0,13
+Gordon,OOSTANAULA,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,6,0,7,0,13
+Gordon,OAKMAN,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,16,0,1,0,17
+Gordon,GORDON COUNTY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,32,4,11,1,48
+Gordon,CALHOUN CITY,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,53,12,16,0,81
+Gordon,LILY POND,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,12,1,3,0,16
+Gordon,FAIRMOUNT,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,7,2,1,0,10
+Gordon,RED BUD,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,21,2,6,0,29
+Gordon,RESACA,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,10,0,2,0,12
+Gordon,,Commissioner Of Labor,,DEM,ROBBIN K. SHIPP,208,27,62,1,298
+Gordon,SUGAR VALLEY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",104,2,8,0,114
+Gordon,PLAINVILLE,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",119,5,4,0,128
+Gordon,SONORAVILLE,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",382,7,61,0,450
+Gordon,PINE CHAPEL,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",70,0,9,0,79
+Gordon,OOSTANAULA,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",53,3,11,0,67
+Gordon,OAKMAN,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",68,0,4,1,73
+Gordon,GORDON COUNTY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",285,9,92,1,387
+Gordon,CALHOUN CITY,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",388,19,143,0,550
+Gordon,LILY POND,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",138,4,33,0,175
+Gordon,FAIRMOUNT,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",150,1,16,1,168
+Gordon,RED BUD,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",170,5,32,0,207
+Gordon,RESACA,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",117,2,12,1,132
+Gordon,,U.S. Representative,14,REP,"J.T. ""TOM"" GRAVES (I)",2044,57,425,4,2530
+Gordon,SUGAR VALLEY,U.S. Representative,14,REP,KENNETH L. HERRON SR,67,0,14,0,81
+Gordon,PLAINVILLE,U.S. Representative,14,REP,KENNETH L. HERRON SR,56,1,10,0,67
+Gordon,SONORAVILLE,U.S. Representative,14,REP,KENNETH L. HERRON SR,171,2,30,0,203
+Gordon,PINE CHAPEL,U.S. Representative,14,REP,KENNETH L. HERRON SR,38,0,6,0,44
+Gordon,OOSTANAULA,U.S. Representative,14,REP,KENNETH L. HERRON SR,37,1,2,0,40
+Gordon,OAKMAN,U.S. Representative,14,REP,KENNETH L. HERRON SR,37,1,5,0,43
+Gordon,GORDON COUNTY,U.S. Representative,14,REP,KENNETH L. HERRON SR,172,4,50,0,226
+Gordon,CALHOUN CITY,U.S. Representative,14,REP,KENNETH L. HERRON SR,256,5,109,1,371
+Gordon,LILY POND,U.S. Representative,14,REP,KENNETH L. HERRON SR,69,1,13,0,83
+Gordon,FAIRMOUNT,U.S. Representative,14,REP,KENNETH L. HERRON SR,74,3,9,0,86
+Gordon,RED BUD,U.S. Representative,14,REP,KENNETH L. HERRON SR,81,4,9,0,94
+Gordon,RESACA,U.S. Representative,14,REP,KENNETH L. HERRON SR,45,0,3,0,48
+Gordon,,U.S. Representative,14,REP,KENNETH L. HERRON SR,1103,22,260,1,1386
+Gordon,SUGAR VALLEY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",119,1,18,0,138
+Gordon,PLAINVILLE,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",127,2,8,0,137
+Gordon,OOSTANAULA,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",52,3,12,0,67
+Gordon,GORDON COUNTY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",321,11,94,1,427
+Gordon,CALHOUN CITY,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",435,16,160,1,612
+Gordon,LILY POND,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",133,3,31,0,167
+Gordon,RESACA,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",4,0,0,0,4
+Gordon,,State Senator,52,REP,"C.E. ""CHUCK"" HUFSTETLER (I)",1191,36,323,2,1552
+Gordon,SONORAVILLE,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",395,5,61,0,461
+Gordon,PINE CHAPEL,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",67,0,10,0,77
+Gordon,OAKMAN,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",77,1,6,1,85
+Gordon,FAIRMOUNT,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",159,2,16,1,178
+Gordon,RED BUD,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",170,7,37,0,214
+Gordon,RESACA,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",105,1,10,1,117
+Gordon,,State Senator,54,REP,"CHARLES J. ""CHARLIE"" BETHEL (I)",973,16,140,3,1132
+Gordon,SUGAR VALLEY,State Representative,5,REP,JOHN D. MEADOWS (I),124,2,19,0,145
+Gordon,PLAINVILLE,State Representative,5,REP,JOHN D. MEADOWS (I),132,1,7,0,140
+Gordon,SONORAVILLE,State Representative,5,REP,JOHN D. MEADOWS (I),246,1,33,0,280
+Gordon,PINE CHAPEL,State Representative,5,REP,JOHN D. MEADOWS (I),77,0,10,0,87
+Gordon,OOSTANAULA,State Representative,5,REP,JOHN D. MEADOWS (I),58,4,11,0,73
+Gordon,GORDON COUNTY,State Representative,5,REP,JOHN D. MEADOWS (I),346,12,107,1,466
+Gordon,CALHOUN CITY,State Representative,5,REP,JOHN D. MEADOWS (I),484,19,187,1,691
+Gordon,LILY POND,State Representative,5,REP,JOHN D. MEADOWS (I),141,4,37,0,182
+Gordon,RED BUD,State Representative,5,REP,JOHN D. MEADOWS (I),180,7,32,0,219
+Gordon,RESACA,State Representative,5,REP,JOHN D. MEADOWS (I),117,1,9,1,128
+Gordon,,State Representative,5,REP,JOHN D. MEADOWS (I),1905,51,452,3,2411
+Gordon,SONORAVILLE,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",167,7,31,0,205
+Gordon,OAKMAN,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",79,1,5,1,86
+Gordon,FAIRMOUNT,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",170,2,17,1,190
+Gordon,RED BUD,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",1,0,4,0,5
+Gordon,,State Representative,11,REP,"R.C. ""RICK"" JASPERSE (I)",417,10,57,2,486
+Gordon,SONORAVILLE,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",9,0,2,0,11
+Gordon,OAKMAN,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",17,0,1,0,18
+Gordon,FAIRMOUNT,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",7,2,1,0,10
+Gordon,RED BUD,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",0,0,0,0,0
+Gordon,,State Representative,11,DEM,"CHARLES O. ""CHUCK"" HENDRIX",33,2,4,0,39


### PR DESCRIPTION
This fixes the [duplicate entries](https://github.com/openelections/openelections-data-ga/runs/3518580413?check_suite_focus=true) in [2014/20140520__ga__primary__gordon__precinct.csv](https://github.com/openelections/openelections-data-ga/blob/5813e5c1c317502250defb4f57ef883c1059f9d9/2014/20140520__ga__primary__gordon__precinct.csv).

According to the [source data](https://results.enr.clarityelections.com/GA/Gordon/51410/130913/en/reports.html#), these values belong to R. "RITA" ROBINZINE:

![image](https://user-images.githubusercontent.com/17345532/132136973-0bc7ce2d-8ea3-4b8f-8944-d2d3718e4193.png)

In doing so, we also fixed the line endings.  The actual fix to the data is contained in revision ef8ec5caead19bec1ef1462ada17653327a4125c.
