### PR TITLE
county_parser: pass lxml to BeautifulSoup to match the rest of the repo

### DIFF
--- a/county_parser.py
+++ b/county_parser.py
@@ -13,7 +13,7 @@ OFFICES = ['United States Senator, Isakson', 'Governor', 'Lieutenant Governor', 
 def parse_statewide_url(url):
     contests = []
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "lxml")
     offices = soup.findAll('strong')[1:]
     for office in offices:
         if office.text in OFFICES:
@@ -33,7 +33,7 @@ def get_candidates(candidates_row):
 
 def parse_county_results(url):
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "lxml")
     table = soup.findAll('table')[2]
     rows = table.findAll('tr')
     candidates = get_candidates(rows[0].find('table').find('tr'))


### PR DESCRIPTION
Two \`BeautifulSoup(r.text)\` calls in \`county_parser.py\` don't specify a parser, which triggers a \`GuessedAtParserWarning\` on every run. Every other script in the repo (\`2006/\`, \`2008/\`, \`2012/\`, \`2022/code/helpers.py\`, etc.) already passes \`'lxml'\` — just matching that here for consistency.

No behavior change; bs4 was likely picking lxml anyway when it's available, this just stops the warning.